### PR TITLE
comment: make predicted label sentiment optional everywhere

### DIFF
--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -398,13 +398,6 @@ pub struct Label {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PredictedLabel {
     pub name: LabelName,
-    pub sentiment: f64,
-    pub probability: f64,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct PredictedLabelParts {
-    pub name: Vec<LabelName>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sentiment: Option<f64>,
     pub probability: f64,

--- a/api/src/resources/trigger.rs
+++ b/api/src/resources/trigger.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use crate::errors::{Error, ErrorKind, Result};
 
 use super::{
-    comment::{Comment, CommentFilter, Entity, LabelName, PredictedLabelParts},
+    comment::{Comment, CommentFilter, Entity, LabelName, PredictedLabel},
     dataset::{FullName as DatasetFullName, Id as DatasetId},
 };
 
@@ -80,7 +80,7 @@ pub struct Batch {
 pub struct TriggerResult {
     pub comment: Comment,
     pub sequence_id: SequenceId,
-    pub labels: Option<Vec<PredictedLabelParts>>,
+    pub labels: Option<Vec<PredictedLabel>>,
     pub entities: Option<Vec<Entity>>,
 }
 


### PR DESCRIPTION
For https://github.com/reinfer/platform/issues/8010

Makes sentiment optional in all predicted label objects (as it should not be present for sentimentless datasets at all).