### PR TITLE
ci: update github actions, add publish workflow for version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,8 @@
-name: Build
+name: Publish
 
 on:
   push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+    tags: v*
 
 env:
   CARGO_TERM_COLOR: always
@@ -25,3 +23,13 @@ jobs:
         run: ./scripts/build
       - name: Run tests
         run: ./scripts/check
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: "299.0.0"
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Publish Binaries
+        run: ./cli/publish-binaries
+      - name: Publish Crates
+        run: |
+          cargo login ${{ secrets.CRATES_IO_TOKEN }}
+          ./scripts/publish

--- a/check
+++ b/check
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -ex
-cd "$(dirname "$0")"
-
-cargo fmt -- --check
-cargo clippy --all-targets --all-features --locked --offline -- -D warnings
-cargo test --offline --locked --all-targets
-cargo test --offline --locked --manifest-path cli/Cargo.toml

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+cargo check --locked --all-targets
+cargo build --locked --all-targets

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+cd "$(dirname "$0")/.."
+
+cargo fmt -- --check
+cargo clippy --offline --locked --all-targets -- -D warnings
+cargo test --offline --locked --all-targets
+cargo test --offline --locked --doc

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+
+cd "$ROOT/api"
+cargo publish
+
+cd "$ROOT/cli"
+cargo publish


### PR DESCRIPTION
Also adds caching for rust dependencies, which should speed up build times.

This will definitely not work until the following secrets are populated by an admin (@mcobzarenco):
- `GCP_SA_KEY`, a GCP Service Account Key which has write access to the `gs://reinfer-public` bucket
- `CRATES_IO_TOKEN`, a crates.io token with publish permissions to the `reinfer-cli` and `reinfer-client` crates.