### PR TITLE
task: Reject duplicate comment ids by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # next
 
+## Added
+- `create comments`: Add check for duplicate comment IDs before attempting upload of a comment file. Use `--allow-duplicates` to skip this check.
+
+## Changed
+- `create comments`, `get comments`, `create emails`: Replace `--progress` flag with `--no-progress`.
+- `create comments`: Stop overwriting existing comments by default. Use `--overwrite` to use the previous behaviour.
+
 # v0.3.2
 
 This release is identical to 0.3.1, but was republished due to a packaging bug.

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -80,6 +80,14 @@ pub struct CommentsIterPage {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub(crate) struct PutCommentsRequest<'request> {
+    pub comments: &'request [NewComment],
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PutCommentsResponse;
+
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct SyncCommentsRequest<'request> {
     pub comments: &'request [NewComment],
 }

--- a/cli/src/commands/create/emails.rs
+++ b/cli/src/commands/create/emails.rs
@@ -32,9 +32,9 @@ pub struct CreateEmailsArgs {
     /// Number of emails to batch in a single request.
     batch_size: usize,
 
-    #[structopt(long = "progress")]
-    /// Whether to display a progress bar. Only applicable when a file is used.
-    progress: Option<bool>,
+    #[structopt(long)]
+    /// Don't display a progress bar (only applicable when --file is used).
+    no_progress: bool,
 }
 
 pub fn create(client: &Client, args: &CreateEmailsArgs) -> Result<()> {
@@ -60,10 +60,10 @@ pub fn create(client: &Client, args: &CreateEmailsArgs) -> Result<()> {
                 ErrorKind::Config(format!("Could not open file `{}`", emails_path.display()))
             })?);
             let statistics = Arc::new(Statistics::new());
-            let progress = if args.progress.unwrap_or(true) {
-                Some(progress_bar(file_metadata.len(), &statistics))
-            } else {
+            let progress = if args.no_progress {
                 None
+            } else {
+                Some(progress_bar(file_metadata.len(), &statistics))
             };
             upload_emails_from_reader(&client, &bucket, file, args.batch_size, &statistics)?;
             if let Some(mut progress) = progress {

--- a/cli/src/commands/get.rs
+++ b/cli/src/commands/get.rs
@@ -63,9 +63,9 @@ pub enum GetArgs {
         /// Dataset name or id
         dataset: Option<DatasetIdentifier>,
 
-        #[structopt(long = "progress")]
-        /// Whether to display a progress bar.
-        show_progress: Option<bool>,
+        #[structopt(long)]
+        /// Don't display a progress bar (only applicable when --file is used).
+        no_progress: bool,
 
         #[structopt(long = "predictions")]
         /// Save predicted labels and entities for each comment.
@@ -196,7 +196,7 @@ pub fn run(get_args: &GetArgs, client: Client) -> Result<()> {
         GetArgs::Comments {
             source,
             dataset,
-            show_progress,
+            no_progress,
             include_predictions,
             reviewed_only,
             from_timestamp,
@@ -233,7 +233,7 @@ pub fn run(get_args: &GetArgs, client: Client) -> Result<()> {
                     from: *from_timestamp,
                     to: *to_timestamp,
                 },
-                show_progress: show_progress.unwrap_or(true),
+                show_progress: !no_progress,
             };
 
             if let Some(file) = file {

--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -12,6 +12,9 @@ pub enum ErrorKind {
     #[fail(display = "{}", 0)]
     Config(String),
 
+    #[fail(display = "Input error: {}", 0)]
+    Input(String),
+
     #[fail(display = "Unknown shell `{}`", 0)]
     UnknownShell(String),
 

--- a/cli/tests/samples/duplicates.jsonl
+++ b/cli/tests/samples/duplicates.jsonl
@@ -1,0 +1,5 @@
+{"comment":{"id":"1","timestamp":"2018-10-25T00:00:00Z","messages":[{"body":{"text":"Comment 1."}}]}}
+{"comment":{"id":"2","timestamp":"2018-10-25T00:00:00Z","messages":[{"body":{"text":"Comment 2"}}]}}
+{"comment":{"id":"3","timestamp":"2018-10-25T00:00:00Z","messages":[{"body":{"text":"Comment 3"}}]}}
+{"comment":{"id":"1","timestamp":"2018-10-30T00:00:00Z","messages":[{"body":{"text":"Comment 4 (with duplicate ID 1)."}}]}}
+{"comment":{"id":"4","timestamp":"2018-10-30T00:00:00Z","messages":[{"body":{"text":"Comment 5"}}]}}


### PR DESCRIPTION
This PR introduces two flags:

- `--allow-duplicates` - if set, comments with duplicate IDs are permitted for upload. If not set, the file is checked for duplicate IDs before the upload start. **I made it mandatory to specify this flag if uploading from stdin.**
- `--overwrite` - if set, uses the `/sync` endpoint instead of put endpoint.

The current behaviour is equivalent to `--allow-duplicates --overwrite`, so this PR makes the CLI stricter with the intention of catch erroneous data upload earlier.