### PR TITLE
Release v0.4.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 on:
-  push:
-    tags: v*
+  release:
+    types: [published]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# next
+# v0.4.0
 
 ## Added
 - `create comments`: Add check for duplicate comment IDs before attempting upload of a comment file. Use `--allow-duplicates` to skip this check.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "reinfer-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "colored",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "reinfer-client"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "failchain",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinfer-client"
-version = "0.3.2"
+version = "0.4.0"
 description = "API client for Re:infer"
 homepage = "https://github.com/reinfer/cli"
 readme = "README.md"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinfer-cli"
-version = "0.3.2"
+version = "0.4.0"
 description = "Command line interface for the reinfer platform."
 homepage = "https://github.com/reinfer/cli"
 readme = "README.md"
@@ -29,4 +29,4 @@ serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 structopt = { version = "0.3.15", default-features = false }
 
-reinfer-client = { version = "0.3.2", path = "../api" }
+reinfer-client = { version = "0.4.0", path = "../api" }


### PR DESCRIPTION
Version bumps plus change `publish.yml` to trigger based on Github release.