### PR TITLE
task: improve invalid source name error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # next
 
+## Changed
+- `create source`: Improve error message when specifying an invalid source name.
+
 # v0.4.0
 
 ## Added

--- a/api/src/resources/source.rs
+++ b/api/src/resources/source.rs
@@ -36,6 +36,21 @@ pub struct Name(pub String);
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FullName(pub String);
 
+impl FromStr for FullName {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self> {
+        if string.split('/').count() == 2 {
+            Ok(FullName(string.into()))
+        } else {
+            Err(ErrorKind::BadSourceIdentifier {
+                identifier: string.into(),
+            }
+            .into())
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Id(pub String);
 
@@ -65,13 +80,8 @@ impl FromStr for Identifier {
     fn from_str(string: &str) -> Result<Self> {
         if string.chars().all(|c| c.is_digit(16)) {
             Ok(Identifier::Id(Id(string.into())))
-        } else if string.split('/').count() == 2 {
-            Ok(Identifier::FullName(FullName(string.into())))
         } else {
-            Err(ErrorKind::BadSourceIdentifier {
-                identifier: string.into(),
-            }
-            .into())
+            FullName::from_str(string).map(Identifier::FullName)
         }
     }
 }

--- a/cli/src/commands/create/source.rs
+++ b/cli/src/commands/create/source.rs
@@ -9,7 +9,7 @@ use crate::errors::{ErrorKind, Result};
 pub struct CreateSourceArgs {
     #[structopt(name = "source-name")]
     /// Full name of the new source <owner>/<name>
-    name: String,
+    name: SourceFullName,
 
     #[structopt(long = "title")]
     /// Set the title of the new source
@@ -60,7 +60,7 @@ pub fn create(client: &Client, args: &CreateSourceArgs) -> Result<()> {
 
     let source = client
         .create_source(
-            &SourceFullName(name.clone()),
+            &name,
             NewSource {
                 title: title.as_ref().map(|title| title.as_str()),
                 description: description.as_ref().map(|description| description.as_str()),

--- a/cli/tests/test_sources.rs
+++ b/cli/tests/test_sources.rs
@@ -114,3 +114,20 @@ fn test_create_source_custom() {
     assert_eq!(source_info.language, "de");
     assert_eq!(source_info.should_translate, true);
 }
+
+#[test]
+fn test_create_source_requires_owner() {
+    let cli = TestCli::get();
+
+    let output = cli
+        .command()
+        .args(&["create", "source", "source-without-owner"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr).trim(),
+        "error: Invalid value for '<source-name>': Expected <owner>/<name> or a source id, got: source-without-owner"
+    );
+}


### PR DESCRIPTION
This improves the output of `re create source source-missing-owner` from:

```
E Operation to create a source has failed
E  |- API request failed with 405 Method Not Allowed: 405 Method Not Allowed
```

to:

```
error: Invalid value for '<source-name>': Expected <owner>/<name> or a source id, got: no-owner
```

The best way to test this was via an integration test, so please merge #22 first. After then I'll rebase this PR to isolate just the relevant changes (from `89aea98`).