### PR TITLE
task: Add retry on timeout for multi-request cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changed
 - `create source`: Improve error message when specifying an invalid source name.
+- Commands which make multiple API requests will now retry on timeout for requests after the first.
 - Bump all dependencies to latest versions.
 
 # v0.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
+name = "assert-json-diff"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0"
+dependencies = [
+ "extend",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +181,17 @@ dependencies = [
 
 [[package]]
 name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
@@ -261,6 +283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +351,18 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "extend"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -761,6 +801,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a634720d366bcbce30fb05871a35da229cef101ad0b2ea4e46cf5abf031a273"
+dependencies = [
+ "assert-json-diff",
+ "colored 1.9.3",
+ "difference",
+ "httparse",
+ "lazy_static",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,7 +1139,7 @@ name = "reinfer-cli"
 version = "0.4.0"
 dependencies = [
  "chrono",
- "colored",
+ "colored 2.0.0",
  "dirs 3.0.1",
  "env_logger",
  "failchain",
@@ -1109,6 +1167,7 @@ dependencies = [
  "failure_derive",
  "lazy_static",
  "log",
+ "mockito",
  "reqwest",
  "serde",
  "serde_json",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,3 +21,6 @@ log = "0.4.8"
 reqwest = { version = "0.10.6", default-features = false, features = ["blocking", "gzip", "json", "native-tls-vendored"] }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
+
+[dev-dependencies]
+mockito = "0.27.0"

--- a/api/src/retry.rs
+++ b/api/src/retry.rs
@@ -1,0 +1,204 @@
+use reqwest::{blocking::Response, Result};
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+use std::thread::sleep;
+use std::time::Duration;
+
+/// Strategy to use if retrying .
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RetryStrategy {
+    /// The first request by the client will not be retried, but subsequent requests will.
+    /// This allows fast failure if the client cannot reach the API endpoint at all, but
+    /// helps to mitigate failure in long-running operations spanning multiple requests.
+    Automatic,
+    /// Always attempt to retry requests.
+    Always,
+}
+
+/// Configuration for the Reinfer client if retrying timeouts.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RetryConfig {
+    /// Strategy for when to retry after a timeout
+    pub strategy: RetryStrategy,
+    /// Maximum number of retries to attempt.
+    pub max_retry_count: u8,
+    /// Amount of time to wait for first retry.
+    pub base_wait: Duration,
+    /// Amount of time to scale retry waits. The wait before retry N is an exponential backoff
+    /// using the formula `wait = retry_wait * (backoff_factor * N)`.
+    pub backoff_factor: f64,
+}
+
+#[derive(Debug)]
+pub(crate) struct Retrier {
+    config: RetryConfig,
+    is_first_request: AtomicBool,
+}
+
+impl Retrier {
+    pub fn new(config: RetryConfig) -> Self {
+        Self {
+            config,
+            is_first_request: AtomicBool::new(true),
+        }
+    }
+
+    pub fn with_retries(&self, send_request: impl Fn() -> Result<Response>) -> Result<Response> {
+        if self.is_first_request.swap(false, SeqCst)
+            && self.config.strategy == RetryStrategy::Automatic
+        {
+            return send_request();
+        }
+
+        for i_retry in 0..self.config.max_retry_count {
+            macro_rules! warn_and_sleep {
+                ($src:expr) => {{
+                    let wait_factor = self.config.backoff_factor.powi(i_retry.into());
+                    let duration = self.config.base_wait.mul_f64(wait_factor);
+                    log::warn!("{} - retrying after {:?}.", $src, duration);
+                    sleep(duration)
+                }};
+            };
+
+            match send_request() {
+                Ok(response) if response.status().is_server_error() => {
+                    warn_and_sleep!(format!("{} for {}", response.status(), response.url()))
+                }
+                Err(error) if error.is_timeout() => warn_and_sleep!(error),
+                // If anything else, just return it immediately
+                result => return result,
+            }
+        }
+
+        // On last retry don't handle the error, just propagate all errors.
+        send_request()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Retrier, RetryConfig, RetryStrategy};
+    use mockito::{mock, server_address};
+    use reqwest::blocking::{get, Client};
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    #[test]
+    fn test_always_retry() {
+        let mut handler = Retrier::new(RetryConfig {
+            strategy: RetryStrategy::Always,
+            max_retry_count: 5,
+            base_wait: Duration::from_secs(0),
+            backoff_factor: 0.0,
+        });
+
+        // Does not attempt to retry on success
+        let ok = mock("GET", "/").expect(1).create();
+        assert!(
+            handler
+                .with_retries(|| get(&format!("http://{}", server_address())))
+                .unwrap()
+                .status()
+                == 200
+        );
+        ok.assert();
+
+        // Retries up to N times on timeout.
+        for i_retry in 0..10 {
+            let err = mock("GET", "/")
+                .with_status(500)
+                .expect((i_retry + 1).into())
+                .create();
+            handler.config.max_retry_count = i_retry;
+            assert!(
+                handler
+                    .with_retries(|| get(&format!("http://{}", server_address())))
+                    .unwrap()
+                    .status()
+                    == 500
+            );
+            err.assert();
+        }
+    }
+
+    #[test]
+    fn test_automatic_retry() {
+        let mut handler = Retrier::new(RetryConfig {
+            strategy: RetryStrategy::Automatic,
+            max_retry_count: 5,
+            base_wait: Duration::from_secs(0),
+            backoff_factor: 0.0,
+        });
+
+        // Does not attempt to retry on failure of first request
+        let err = mock("GET", "/").with_status(500).expect(1).create();
+        assert!(
+            handler
+                .with_retries(|| get(&format!("http://{}", server_address())))
+                .unwrap()
+                .status()
+                == 500
+        );
+        err.assert();
+
+        // Does not attempt to retry on success
+        let ok = mock("GET", "/").expect(1).create();
+        assert!(
+            handler
+                .with_retries(|| get(&format!("http://{}", server_address())))
+                .unwrap()
+                .status()
+                == 200
+        );
+        ok.assert();
+
+        // Retries up to N times on timeout for non-first-requests.
+        for i_retry in 0..10 {
+            let err = mock("GET", "/")
+                .with_status(500)
+                .expect((i_retry + 1).into())
+                .create();
+            handler.config.max_retry_count = i_retry;
+            assert!(
+                handler
+                    .with_retries(|| get(&format!("http://{}", server_address())))
+                    .unwrap()
+                    .status()
+                    == 500
+            );
+            err.assert();
+        }
+    }
+
+    #[test]
+    fn test_timeout_retry() {
+        let handler = Retrier::new(RetryConfig {
+            strategy: RetryStrategy::Always,
+            max_retry_count: 1,
+            base_wait: Duration::from_secs(0),
+            backoff_factor: 0.0,
+        });
+
+        // Should retry on the timeout
+        let timeout = mock("GET", "/")
+            .with_body_from_fn(|_| {
+                sleep(Duration::from_secs_f64(0.2));
+                Ok(())
+            })
+            .expect(2)
+            .create();
+        let client = Client::new();
+        assert!(handler
+            .with_retries(|| client
+                .get(&format!("http://{}", server_address()))
+                .timeout(Duration::from_secs_f64(0.1))
+                .send()
+                .and_then(|r| {
+                    // This is a bit of a hack to force a timeout
+                    let _ = r.text()?;
+                    unreachable!()
+                }))
+            .unwrap_err()
+            .is_timeout());
+        timeout.assert();
+    }
+}


### PR DESCRIPTION
Add timeout handling at the `reinfer_client` level for API requests. It's disabled by default in the library config.

The CLI enables it to what I call "automatic" timeout handling, which attempts to retry all requests except for the very first. This should mean that if the first request fails with a timeout, the CLI assumes the configured endpoint is invalid and won't retry, leading to a nice quick failure.

For longer-running operations spanning multiple requests, this should lead to nice stability in the face of network connection blips.

This is what stderr looks like when the retry kicks in:

```
W error sending request for url (https://foobarwat.com/qux): operation timed out - retrying after 10s.
W error sending request for url (https://foobarwat.com/qux): operation timed out - retrying after 20s.
W error sending request for url (https://foobarwat.com/qux): operation timed out - retrying after 40s.
E Operation to get the current user has failed.
E  |- An unknown error has occurred: GET operation failed.
E  |- error sending request for url (https://foobarwat.com/qux): operation timed out
```