### PR TITLE
ci: Add clippy as separate job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy
+      # Needs to be separate job because clippy currently (incorrectly) shares cache with cargo
+      # (See https://github.com/rust-lang/rust-clippy/issues/4612)
+      - name: Run clippy
+        run: cargo clippy
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/cli/src/commands/create/comments.rs
+++ b/cli/src/commands/create/comments.rs
@@ -297,6 +297,7 @@ fn upload_batch(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn upload_comments_from_reader(
     client: &Client,
     source: &Source,


### PR DESCRIPTION
Workaround until clippy correctly invaliding `cargo check` cache is fixed. (See issue referred to in the comment.) 