### PR TITLE
readme: ensure download links up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ The [api](/api) directory contains a Rust client library for reinfer which can b
 
 Statically linked binaries with no dependencies are provided for selected platforms:
 
-- [x86_64-unknown-linux-musl](https://reinfer.io/public/cli/bin/x86_64-unknown-linux-musl/0.3.0/re)
+- [x86_64-unknown-linux-musl](https://reinfer.io/public/cli/bin/x86_64-unknown-linux-musl/0.4.1/re)
 
 ### Debian / Ubuntu
 
-You can download a `.deb` package [here](https://reinfer.io/public/cli/debian/reinfer-cli_0.3.0_amd64.deb).
+You can download a `.deb` package [here](https://reinfer.io/public/cli/debian/reinfer-cli_0.4.1_amd64.deb).
 
 ### From Source
 

--- a/scripts/check
+++ b/scripts/check
@@ -4,6 +4,7 @@ set -ex
 
 cd "$(dirname "$0")/.."
 
+scripts/check-versions
 cargo fmt -- --check
 cargo clippy --offline --locked --all-targets -- -D warnings
 cargo test --offline --locked --all-targets

--- a/scripts/check-versions
+++ b/scripts/check-versions
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -ex
+
+cd "$(dirname "$0")/.."
+
+VERSION=$(grep -e "^version" cli/Cargo.toml | cut -d ' ' -f 3 | tr -d '"')
+echo $VERSION
+
+grep -Fq "https://reinfer.io/public/cli/bin/x86_64-unknown-linux-musl/$VERSION/re" README.md || \
+    (echo "README.md has out-of-date binary link" && exit 1)
+
+grep -Fq "https://reinfer.io/public/cli/debian/reinfer-cli_${VERSION}_amd64.deb" README.md || \
+    (echo "README.md has out-of-date deb link" && exit 1)


### PR DESCRIPTION
Update the download links in the readme, and add a very hacky check to CI to ensure this always gets done as part of release.