### PR TITLE
api/cli: add 'delete comments' to delete comments by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+# Unreleased
+
+## Added
+
+- `delete comments`: For deleting multiple comments by comment id from a source.
+
 # v0.4.1
 
 ## Changed
+
 - `create source`: Improve error message when specifying an invalid source name.
 - Commands which make multiple API requests will now retry on timeout for requests after the first.
 - Bump all dependencies to latest versions.
@@ -8,9 +15,11 @@
 # v0.4.0
 
 ## Added
+
 - `create comments`: Add check for duplicate comment IDs before attempting upload of a comment file. Use `--allow-duplicates` to skip this check.
 
 ## Changed
+
 - `create comments`, `get comments`, `create emails`: Replace `--progress` flag with `--no-progress`.
 - `create comments`: Stop overwriting existing comments by default. Use `--overwrite` to use the previous behaviour.
 

--- a/cli/src/commands/delete.rs
+++ b/cli/src/commands/delete.rs
@@ -1,6 +1,6 @@
 use failchain::ResultExt;
 use log::info;
-use reinfer_client::{BucketIdentifier, Client, DatasetIdentifier, SourceIdentifier};
+use reinfer_client::{BucketIdentifier, Client, CommentId, DatasetIdentifier, SourceIdentifier};
 use structopt::StructOpt;
 
 use crate::errors::{ErrorKind, Result};
@@ -13,6 +13,18 @@ pub enum DeleteArgs {
         #[structopt(name = "source")]
         /// Name or id of the source to delete
         source: SourceIdentifier,
+    },
+
+    #[structopt(name = "comments")]
+    /// Delete comments by id in a source.
+    Comments {
+        #[structopt(short = "s", long = "source")]
+        /// Name or id of the source to delete comments from
+        source: SourceIdentifier,
+
+        #[structopt(name = "comment id")]
+        /// Ids of the comments to delete
+        comments: Vec<CommentId>,
     },
 
     #[structopt(name = "bucket")]
@@ -39,6 +51,14 @@ pub fn run(delete_args: &DeleteArgs, client: Client) -> Result<()> {
                 ErrorKind::Unknown("Operation to delete source has failed.".into())
             })?;
             info!("Deleted source.");
+        }
+        DeleteArgs::Comments { source, comments } => {
+            client
+                .delete_comments(source.clone(), comments)
+                .chain_err(|| {
+                    ErrorKind::Unknown("Operation to delete comments has failed.".into())
+                })?;
+            info!("Deleted comments.");
         }
         DeleteArgs::Dataset { dataset } => {
             client.delete_dataset(dataset.clone()).chain_err(|| {

--- a/cli/tests/test_comments.rs
+++ b/cli/tests/test_comments.rs
@@ -1,12 +1,20 @@
 use crate::{TestCli, TestSource};
+use reinfer_client::NewAnnotatedComment;
 
 const SAMPLE_BASIC: &str = include_str!("./samples/basic.jsonl");
 
 #[test]
-fn test_upload_comments() {
+fn test_comments_lifecycle() {
+    let annotated_comments: Vec<NewAnnotatedComment> = SAMPLE_BASIC
+        .lines()
+        .map(serde_json::from_str)
+        .collect::<Result<_, _>>()
+        .unwrap();
+
     let cli = TestCli::get();
     let source = TestSource::new();
 
+    // Upload our test data
     let output = cli.run_with_stdin(
         &[
             "create",
@@ -16,5 +24,33 @@ fn test_upload_comments() {
         ],
         SAMPLE_BASIC.as_bytes(),
     );
+    assert!(output.is_empty());
+
+    let output = cli.run(&["get", "comments", &source.identifier().to_string()]);
+    assert_eq!(output.lines().count(), annotated_comments.len());
+
+    // Deleting one comment reduces the comment count in the source
+    let output = cli.run(&[
+        "delete",
+        "comments",
+        &format!("--source={}", source.identifier()),
+        &annotated_comments.iter().next().unwrap().comment.id.0,
+    ]);
+    assert!(output.is_empty());
+
+    let output = cli.run(&["get", "comments", &source.identifier().to_string()]);
+    assert_eq!(output.lines().count(), annotated_comments.len() - 1);
+
+    // Delete all ids
+    let mut args = vec!["delete", "comments", "--source", source.identifier()];
+    args.extend(
+        annotated_comments
+            .iter()
+            .map(|annotated_comment| annotated_comment.comment.id.0.as_str()),
+    );
+    let output = cli.run(&args);
+    assert!(output.is_empty());
+
+    let output = cli.run(&["get", "comments", &source.identifier().to_string()]);
     assert!(output.is_empty());
 }


### PR DESCRIPTION
Adds the ability to delete comments by id in a source.

Example usage:

```bash
cargo run -- delete comments --source org1/naughty-comments plain_comment plain_comment_translated
```

Includes factoring out:

- `id_list_query` as a more generic implmentation
- `get` to reuse `get_query` (to follow the pattern of `delete_query`)