### PR TITLE
tests: require integration tests to be explicit about organisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,9 +890,9 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "openssl"

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use reinfer_client::User;
 use std::{
     env,
     ffi::OsStr,
@@ -28,21 +27,9 @@ impl TestCli {
         &TEST_CLI
     }
 
-    pub fn organisation() -> &'static str {
-        lazy_static! {
-            static ref ORGANISATION: String = {
-                if let Ok(org) = env::var("REINFER_CLI_TEST_ORG") {
-                    org
-                } else {
-                    // For convenience default to username being the same as the organisation
-                    let user_output = TestCli::get().run(&["get", "current-user", "--output=json"]);
-                    let user: User = serde_json::from_str(user_output.trim()).unwrap();
-                    user.username.0
-                }
-            };
-        };
-
-        &ORGANISATION
+    pub fn organisation() -> String {
+        env::var("REINFER_CLI_TEST_ORG")
+            .expect("REINFER_CLI_TEST_ORG must be set for integration tests")
     }
 
     pub fn command(&self) -> Command {


### PR DESCRIPTION
At the moment to be "smart" the integration tests try to default the organisation to be the same as the username.

Almost always a user doesn't have an organisation which matches their username, so this often fails.

Also implicit behaviour is probably not good. These tests now require the env variable to be set explicitly.