### PR TITLE
buckets: add transform tag to create and get commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - `delete comments`: For deleting multiple comments by comment id from a source.
 
+## Changed
+
+- `create bucket`: Accept an optional `--transform-tag` value for the new bucket.
+- `get buckets`: Display transform tag for retrieved data.
+
 # v0.4.1
 
 ## Changed

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -55,7 +55,7 @@ pub use crate::{
     resources::{
         bucket::{
             Bucket, BucketType, FullName as BucketFullName, Id as BucketId,
-            Identifier as BucketIdentifier, Name as BucketName, NewBucket,
+            Identifier as BucketIdentifier, Name as BucketName, NewBucket, TransformTag,
         },
         comment::{
             AnnotatedComment, Comment, CommentFilter, CommentsIterPage, Continuation, Entity,

--- a/api/src/resources/bucket.rs
+++ b/api/src/resources/bucket.rs
@@ -15,6 +15,8 @@ pub struct Bucket {
     pub owner: Username,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub transform_tag: Option<TransformTag>,
 }
 
 impl Bucket {
@@ -34,6 +36,17 @@ pub struct Id(pub String);
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ModelFamily(pub String);
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TransformTag(pub String);
+
+impl FromStr for TransformTag {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self> {
+        Ok(Self(string.to_owned()))
+    }
+}
 
 // TODO(mcobzarenco)[3963]: Make `Identifier` into a trait (ensure it still implements
 // `FromStr` so we can take T: Identifier as a clap command line argument).
@@ -98,6 +111,8 @@ pub struct NewBucket<'request> {
     pub bucket_type: BucketType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<&'request str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transform_tag: Option<&'request TransformTag>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/cli/src/commands/create/bucket.rs
+++ b/cli/src/commands/create/bucket.rs
@@ -1,6 +1,6 @@
 use failchain::ResultExt;
 use log::info;
-use reinfer_client::{BucketFullName, BucketType, Client, NewBucket};
+use reinfer_client::{BucketFullName, BucketType, Client, NewBucket, TransformTag};
 use structopt::StructOpt;
 
 use crate::errors::{ErrorKind, Result};
@@ -18,6 +18,11 @@ pub struct CreateBucketArgs {
     #[structopt(default_value, long = "type")]
     /// Set the type of the new bucket. Currently, this must be "emails".
     bucket_type: BucketType,
+
+    #[structopt(long = "transform-tag")]
+    /// Set the transform tag of the new bucket. You will be given this value
+    /// by a Re:infer engineer.
+    transform_tag: Option<TransformTag>,
 }
 
 pub fn create(client: &Client, args: &CreateBucketArgs) -> Result<()> {
@@ -25,6 +30,7 @@ pub fn create(client: &Client, args: &CreateBucketArgs) -> Result<()> {
         ref name,
         ref title,
         bucket_type,
+        ref transform_tag,
     } = *args;
 
     let bucket = client
@@ -33,6 +39,7 @@ pub fn create(client: &Client, args: &CreateBucketArgs) -> Result<()> {
             NewBucket {
                 title: title.as_ref().map(|title| title.as_str()),
                 bucket_type,
+                transform_tag: transform_tag.as_ref(),
             },
         )
         .chain_err(|| ErrorKind::Client("Operation to create a bucket has failed".into()))?;

--- a/cli/src/commands/get.rs
+++ b/cli/src/commands/get.rs
@@ -579,7 +579,7 @@ fn print_sources_table(sources: &[Source]) {
 
 fn print_buckets_table(buckets: &[Bucket]) {
     let mut table = new_table();
-    table.set_titles(row![bFg => "Name", "ID", "Created (UTC)", "Updated (UTC)"]);
+    table.set_titles(row![bFg => "Name", "ID", "Created (UTC)", "Updated (UTC)", "Transform Tag"]);
     for bucket in buckets.iter() {
         let full_name = format!(
             "{}{}{}",
@@ -592,6 +592,10 @@ fn print_buckets_table(buckets: &[Bucket]) {
             bucket.id.0,
             bucket.created_at.format("%Y-%m-%d %H:%M:%S"),
             bucket.updated_at.format("%Y-%m-%d %H:%M:%S"),
+            match &bucket.transform_tag {
+                Some(transform_tag) => transform_tag.0.as_str().into(),
+                None => "missing".dimmed(),
+            }
         ]);
     }
     table.printstd();

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -50,6 +50,10 @@ impl TestCli {
         self.output(self.command().args(args))
     }
 
+    pub fn run_and_error(&self, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> String {
+        self.output_error(self.command().args(args))
+    }
+
     pub fn run_with_stdin(
         &self,
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
@@ -87,5 +91,18 @@ impl TestCli {
         }
 
         String::from_utf8(output.stdout).unwrap()
+    }
+
+    pub fn output_error(&self, command: &mut Command) -> String {
+        let output = command.output().unwrap();
+
+        if output.status.success() {
+            panic!(
+                "succeeded running command (expected failure):\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+        }
+
+        String::from_utf8(output.stderr).unwrap()
     }
 }

--- a/cli/tests/test_buckets.rs
+++ b/cli/tests/test_buckets.rs
@@ -1,0 +1,44 @@
+use crate::TestCli;
+use uuid::Uuid;
+
+#[test]
+fn test_bucket_lifecycle() {
+    let cli = TestCli::get();
+    let owner = TestCli::organisation();
+
+    let new_bucket_name = format!("{}/test-source-{}", owner, Uuid::new_v4());
+
+    // Create bucket
+    let output = cli.run(&["create", "bucket", &new_bucket_name]);
+    assert!(output.is_empty());
+
+    let output = cli.run(&["get", "buckets"]);
+    assert!(output.contains(&new_bucket_name));
+
+    // Deleting one comment reduces the comment count in the source
+    let output = cli.run(&["delete", "bucket", &new_bucket_name]);
+    assert!(output.is_empty());
+
+    let output = cli.run(&["get", "buckets"]);
+    assert!(!output.contains(&new_bucket_name));
+}
+
+#[test]
+fn test_bucket_with_invalid_transform_tag_fails() {
+    let cli = TestCli::get();
+    let owner = TestCli::organisation();
+
+    let new_bucket_name = format!("{}/test-source-{}", owner, Uuid::new_v4());
+
+    let output = cli.run_and_error(&[
+        "create",
+        "bucket",
+        &new_bucket_name,
+        "--transform-tag",
+        "not-a-valid-transform-tag.0.ABCDEFGH",
+    ]);
+    assert!(
+        output.contains(
+        "422 Unprocessable Entity: The value 'not-a-valid-transform-tag.0.ABCDEFGH' is not a valid transform tag.")
+    );
+}

--- a/cli/tests/tests.rs
+++ b/cli/tests/tests.rs
@@ -1,5 +1,6 @@
 mod common;
 
+mod test_buckets;
 mod test_comments;
 mod test_sources;
 


### PR DESCRIPTION
We've already been able to specify this, it was just missing.

Will soon be required, so we'll need to have it in the CLI to create buckets.

![image](https://user-images.githubusercontent.com/12255914/100371119-35295800-2fff-11eb-8799-a1d7c615f875.png)

cc @Joe-Prosser if you're interested in how the cli interacts with the api