### PR TITLE
create-dataset: add label copying and model family args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ re create dataset org/example-dataset -s org/example-source --has-sentiment fals
 
 ## Changed
 
+- `create dataset`: Accept an optional `--model-family` and `--copy-labels-from` for the new dataset.
 - `create bucket`: Accept an optional `--transform-tag` value for the new bucket.
 - `get buckets`: Display transform tag for retrieved data.
 

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -120,6 +120,11 @@ pub struct NewDataset<'request> {
 
     #[serde(skip_serializing_if = "EntityDefs::is_empty")]
     pub entity_defs: &'request EntityDefs,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_family: Option<&'request str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub copy_labels_from: Option<&'request str>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/cli/src/commands/create/dataset.rs
+++ b/cli/src/commands/create/dataset.rs
@@ -30,6 +30,14 @@ pub struct CreateDatasetArgs {
     #[structopt(short = "e", long = "entity-defs", default_value = "[]")]
     /// Entity defs to create at dataset creation, as json
     entity_defs: EntityDefs,
+
+    #[structopt(long = "model-family")]
+    /// Model family to use for the new dataset
+    model_family: Option<String>,
+
+    /// Dataset ID of the dataset to copy labels from
+    #[structopt(long = "copy-labels-from")]
+    copy_labels_from: Option<String>,
 }
 
 pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
@@ -40,6 +48,8 @@ pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
         ref has_sentiment,
         ref sources,
         ref entity_defs,
+        ref model_family,
+        ref copy_labels_from,
     } = *args;
 
     let source_ids = {
@@ -60,10 +70,12 @@ pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
             &DatasetFullName(name.clone()),
             NewDataset {
                 source_ids: &source_ids,
-                title: title.as_ref().map(|title| title.as_str()),
-                description: description.as_ref().map(|description| description.as_str()),
+                title: title.as_deref(),
+                description: description.as_deref(),
                 has_sentiment: *has_sentiment,
                 entity_defs,
+                model_family: model_family.as_deref(),
+                copy_labels_from: copy_labels_from.as_deref(),
             },
         )
         .context("Operation to create a dataset has failed.")?;

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -1,4 +1,4 @@
-use reinfer_client::Dataset;
+use reinfer_client::{Dataset, Source};
 use uuid::Uuid;
 
 use crate::{TestCli, TestSource};
@@ -63,7 +63,6 @@ impl Drop for TestDataset {
 fn test_test_dataset() {
     let cli = TestCli::get();
     let dataset = TestDataset::new();
-
     let identifier = dataset.identifier().to_owned();
 
     let output = cli.run(&["get", "datasets"]);
@@ -109,13 +108,34 @@ fn test_create_dataset_custom() {
 
     let output = cli.run(&["get", "datasets", dataset.identifier(), "--output=json"]);
     let dataset_info: Dataset = serde_json::from_str(&output).unwrap();
-
     assert_eq!(&dataset_info.owner.0, dataset.owner());
     assert_eq!(&dataset_info.name.0, dataset.name());
     assert_eq!(dataset_info.title, "some title");
     assert_eq!(dataset_info.description, "some description");
     assert_eq!(dataset_info.source_ids.len(), 1);
     assert_eq!(dataset_info.has_sentiment, true);
+}
+
+#[test]
+fn test_create_dataset_with_source() {
+    let cli = TestCli::get();
+    let source = TestSource::new();
+    let dataset = TestDataset::new_args(&[&format!("--source={}", source.identifier())]);
+
+    let output = cli.run(&["get", "datasets", "--output=json", dataset.identifier()]);
+    let dataset_info: Dataset = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(&dataset_info.owner.0, dataset.owner());
+    assert_eq!(&dataset_info.name.0, dataset.name());
+
+    let source_output = cli.run(&[
+        "get",
+        "sources",
+        "--output=json",
+        &dataset_info.source_ids.first().unwrap().0,
+    ]);
+    let source_info: Source = serde_json::from_str(source_output.trim()).unwrap();
+    assert_eq!(&source_info.owner.0, source.owner());
+    assert_eq!(&source_info.name.0, source.name());
 }
 
 #[test]
@@ -129,4 +149,39 @@ fn test_create_dataset_requires_owner() {
         .unwrap();
 
     assert!(!output.status.success());
+}
+
+#[test]
+fn test_create_dataset_model_family() {
+    let cli = TestCli::get();
+    let dataset = TestDataset::new_args(&["--model-family==german"]);
+
+    let output = cli.run(&["get", "datasets", "--output=json", dataset.identifier()]);
+    let dataset_info: Dataset = serde_json::from_str(output.trim()).unwrap();
+    assert_eq!(&dataset_info.owner.0, dataset.owner());
+    assert_eq!(&dataset_info.name.0, dataset.name());
+    assert_eq!(&dataset_info.model_family.0, "german");
+}
+
+#[test]
+fn test_create_dataset_wrong_model_family() {
+    let cli = TestCli::get();
+    let output = cli
+        .command()
+        .args(&[
+            "create",
+            "dataset",
+            "--model-family==non-existent-family",
+            &format!(
+                "{}/test-dataset-{}",
+                TestCli::organisation(),
+                Uuid::new_v4()
+            ),
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    dbg!(String::from_utf8_lossy(&output.stderr));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("API request failed with 400 Bad Request: 'non-existent-family' is not one of"))
 }


### PR DESCRIPTION
Adds the `copy_labels_from` and `model_family` arguments for the `create/dataset` route.