### PR TITLE
Allow users to specify EntityDef-s at dataset creation

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -43,6 +43,17 @@ pub enum Error {
     #[error("Expected a valid bucket type, got: {}", bucket_type)]
     BadBucketType { bucket_type: String },
 
+    #[error(
+        "Expected valid json for entity def. Got: '{}', which failed because: '{}'",
+        entity_def,
+        source
+    )]
+    BadEntityDef {
+        entity_def: String,
+        #[source]
+        source: ::serde_json::Error,
+    },
+
     #[error("Could not parse JSON response.")]
     BadJsonResponse(#[source] reqwest::Error),
 

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -470,7 +470,7 @@ fn should_skip_serializing_entities(maybe_entities: &Option<Entities>) -> bool {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct NewEntity {
-    pub kind: EntityKind,
+    pub name: EntityName,
     pub formatted_value: String,
     pub span: NewEntitySpan,
 }
@@ -485,7 +485,7 @@ pub struct NewEntitySpan {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Entity {
-    pub kind: EntityKind,
+    pub name: EntityName,
     pub formatted_value: String,
     pub span: EntitySpan,
 }
@@ -501,15 +501,7 @@ pub struct EntitySpan {
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-pub struct EntityKind(pub String);
-
-impl FromStr for EntityKind {
-    type Err = Error;
-
-    fn from_str(string: &str) -> Result<Self> {
-        Ok(EntityKind(string.to_owned()))
-    }
-}
+pub struct EntityName(pub String);
 
 #[inline]
 fn strip_prefix(string: &mut String, prefix: &str) -> bool {

--- a/cli/src/commands/create/dataset.rs
+++ b/cli/src/commands/create/dataset.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use log::info;
 use reinfer_client::{
-    resources::comment::EntityKind, Client, DatasetFullName, NewDataset, SourceIdentifier,
+    resources::dataset::EntityDefs, Client, DatasetFullName, NewDataset, SourceIdentifier,
 };
 use structopt::StructOpt;
 
@@ -27,9 +27,9 @@ pub struct CreateDatasetArgs {
     /// Names or ids of the sources in the dataset
     sources: Vec<SourceIdentifier>,
 
-    #[structopt(short = "e", long = "entity-kinds")]
-    /// Entity kinds to enable at dataset creation (pass one flag for each kind)
-    entity_kinds: Vec<EntityKind>,
+    #[structopt(short = "e", long = "entity-defs", default_value = "[]")]
+    /// Entity defs to create at dataset creation, as json
+    entity_defs: EntityDefs,
 }
 
 pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
@@ -39,7 +39,7 @@ pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
         ref description,
         ref has_sentiment,
         ref sources,
-        ref entity_kinds,
+        ref entity_defs,
     } = *args;
 
     let source_ids = {
@@ -63,7 +63,7 @@ pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
                 title: title.as_ref().map(|title| title.as_str()),
                 description: description.as_ref().map(|description| description.as_str()),
                 has_sentiment: *has_sentiment,
-                entity_kinds: &entity_kinds,
+                entity_defs,
             },
         )
         .context("Operation to create a dataset has failed.")?;


### PR DESCRIPTION
Currently blocked on deploying the `api` change allowing to use the builtin names inside `inherits_from`.

We currently support the `-e` flag at dataset creation to enable specific entity kinds. However, as we are now in a world that uses `EntityDef`-s, the cli needs to be able to create these more complex objects.

One thing I had to decide was how the user would be passing these objects to the api. I opted for providing the corresponding json object, à la `curl`. Happy to go another way if someone has a better suggestion.

Example use:
```
re create dataset org/example-dataset -s org/example-source --has-sentiment false -e '{"name":"trainable_org","title":"Custom Organisation","inherits_from":["org"],"trainable":true}' -e '{"name":"non_trainable_person","title":"Basic Person","inherits_from":["person"],"trainable":false}'
```
One `-e` flag needs to be passed for each entity def.