### PR TITLE
tests: require test environment to be set

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,3 +44,4 @@ jobs:
         env:
           REINFER_CLI_TEST_ORG: ${{ secrets.REINFER_CLI_TEST_ORG }}
           REINFER_CLI_TEST_TOKEN: ${{ secrets.REINFER_CLI_TEST_TOKEN }}
+          REINFER_CLI_TEST_ENDPOINT: ${{ secrets.REINFER_CLI_TEST_ENDPOINT }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ dependencies = [
  "lazy_static",
  "log",
  "maplit",
+ "once_cell",
  "prettytable-rs",
  "reinfer-client",
  "reqwest",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,6 +24,7 @@ dirs = "3.0.0"
 env_logger = "0.8.2"
 indicatif = "0.15.0"
 lazy_static = "1.4.0"
+once_cell = "1.5.2"
 log = { version = "0.4.8", default-features = false, features = ["release_max_level_info"] }
 maplit = "1.0.2"
 prettytable-rs = "0.8.0"

--- a/cli/tests/test_buckets.rs
+++ b/cli/tests/test_buckets.rs
@@ -10,17 +10,17 @@ fn test_bucket_lifecycle() {
 
     // Create bucket
     let output = cli.run(&["create", "bucket", &new_bucket_name]);
-    assert!(output.is_empty());
+    assert!(output.is_empty(), output);
 
     let output = cli.run(&["get", "buckets"]);
-    assert!(output.contains(&new_bucket_name));
+    assert!(output.contains(&new_bucket_name), output);
 
     // Deleting one comment reduces the comment count in the source
     let output = cli.run(&["delete", "bucket", &new_bucket_name]);
-    assert!(output.is_empty());
+    assert!(output.is_empty(), output);
 
     let output = cli.run(&["get", "buckets"]);
-    assert!(!output.contains(&new_bucket_name));
+    assert!(!output.contains(&new_bucket_name), output);
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn test_bucket_with_invalid_transform_tag_fails() {
     ]);
     assert!(
         output.contains(
-        "422 Unprocessable Entity: The value 'not-a-valid-transform-tag.0.ABCDEFGH' is not a valid transform tag.")
+        "422 Unprocessable Entity: The value 'not-a-valid-transform-tag.0.ABCDEFGH' is not a valid transform tag."), output
     );
 }
 


### PR DESCRIPTION
Replaces #49 as we only need one of the context, or the endpoint + token to be set.