### PR TITLE
api/cli: support for HTTP proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# v0.5.2
+
+ - Add support for using an HTTP proxy for all requests. The proxy configuration is saved as part of the context.
+   Additionally, the proxy can be overridden / specified as a one off using a global command line argument
+   `--proxy https://proxy.example` (e.g. similar to `--endpoint`).
+
 # v0.5.1
 
 ## Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "reinfer-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1057,12 +1057,13 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "url",
  "uuid",
 ]
 
 [[package]]
 name = "reinfer-client"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -1504,14 +1505,15 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ The [api](/api) directory contains a Rust client library for reinfer which can b
 
 Statically linked binaries with no dependencies are provided for selected platforms:
 
-- [Linux (x86_64-unknown-linux-musl)](https://reinfer.io/public/cli/bin/x86_64-unknown-linux-musl/0.5.1/re)
-- [macOS (x86_64-apple-darwin)](https://reinfer.io/public/cli/bin/x86_64-apple-darwin/0.5.1/re)
+- [Linux (x86_64-unknown-linux-musl)](https://reinfer.io/public/cli/bin/x86_64-unknown-linux-musl/0.5.2/re)
+- [macOS (x86_64-apple-darwin)](https://reinfer.io/public/cli/bin/x86_64-apple-darwin/0.5.2/re)
 
 ### Debian / Ubuntu
 
-You can download a `.deb` package [here](https://reinfer.io/public/cli/debian/reinfer-cli_0.5.1_amd64.deb).
+You can download a `.deb` package [here](https://reinfer.io/public/cli/debian/reinfer-cli_0.5.2_amd64.deb).
 
 ### From Source
 
@@ -135,8 +135,9 @@ re --endpoint http://localhost:8000 --token $REINFER_TOKEN get datasets
 Contexts help avoid having to manually specify the token and endpoint with every command. A _context_ is composed of
 
 - The authentication token (which user?)
-- The reinfer endpoint to talk to, typically `https://reinfer.io` (which cluster?)
-- A human rememberable name
+- The Re:infer cluster endpoint to talk to, typically `https://reinfer.io`
+- (Optional) An HTTP proxy to use for all requests
+- A memorable name which serves as an identifier for the "context"
 
 Commands for managing _contexts_ are under `re config` and allow one to create, update, set and delete contexts. Run `re config -h` to see all the options.
 
@@ -150,7 +151,7 @@ W Be careful, API tokens are stored in cleartext in /home/marius/.config/reinfer
 I New context `production` was created.
 ```
 
-The token and endpoint for the current context will be used for all subsequent commands (these be overwritten as a one off using the `--token` and `--endpoint` arguments).
+The current context will be used for all subsequent commands.
 
 ```
 ➜ re get datasets
@@ -160,6 +161,15 @@ The token and endpoint for the current context will be used for all subsequent c
  InvestmentBank/margin-call          b9d50fb2b38c3af5  2019-05-08 07:51:09  IB Margin Call
  InvestmentBank/margin-call-large    6d00b9f69ab059f6  2019-05-11 09:23:43  IB Margin Call Large
 ```
+
+Any of the context settings can be overwritten as a one off using global flags such as `--token`, `--endpoint` and `--proxy`.
+
+```
+➜ re --proxy http://proxy.example get datasets
+```
+
+Adding a context with a name that already exists will allow you to update any of the saved settings.
+
 
 ### Uploading Comments
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinfer-client"
-version = "0.5.1"
+version = "0.5.2"
 description = "API client for Re:infer"
 homepage = "https://github.com/reinfer/cli"
 readme = "README.md"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinfer-cli"
-version = "0.5.1"
+version = "0.5.2"
 description = "Command line interface for the reinfer platform."
 homepage = "https://github.com/reinfer/cli"
 readme = "README.md"
@@ -32,8 +32,9 @@ reqwest = { version = "0.11.0", default-features = false }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.55"
 structopt = { version = "0.3.15", default-features = false }
+url = {version= "2.2.1", features = ["serde"] }
 
-reinfer-client = { version = "0.5.1", path = "../api" }
+reinfer-client = { version = "0.5.2", path = "../api" }
 
 [dev-dependencies]
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -38,10 +38,15 @@ pub struct Args {
     /// context, if any.
     pub token: Option<String>,
 
+    #[structopt(long = "proxy")]
+    /// URL for an HTTP proxy that will be used for all requests if specified
+    pub proxy: Option<Url>,
+
     #[structopt(subcommand)]
     pub command: Command,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, StructOpt)]
 pub enum Command {
     #[structopt(name = "completion")]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -77,13 +77,10 @@ impl ReinferConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ContextConfig {
     pub name: String,
-    #[serde(
-        deserialize_with = "crate::utils::deserialize_url",
-        serialize_with = "crate::utils::serialize_url"
-    )]
     pub endpoint: Url,
     pub token: Option<String>,
     pub accept_invalid_certificates: bool,
+    pub proxy: Option<Url>,
 }
 
 pub fn read_reinfer_config(path: impl AsRef<Path>) -> Result<ReinferConfig> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,6 +87,11 @@ fn client_from_args(args: &Args, config: &ReinferConfig) -> Result<Client> {
         ));
     }
 
+    let proxy = args
+        .proxy
+        .clone()
+        .or_else(|| current_context.and_then(|context| context.proxy.clone()));
+
     // Retry everything but the very first request.
     // Retry wait schedule is [5s, 10s, 20s, fail]. (Plus the time for each attempt to timeout.)
     let retry_config = RetryConfig {
@@ -100,6 +105,7 @@ fn client_from_args(args: &Args, config: &ReinferConfig) -> Result<Client> {
         endpoint,
         token,
         accept_invalid_certificates,
+        proxy,
         retry_config: Some(retry_config),
     })
     .context("Failed to initialise the HTTP client.")

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -3,8 +3,7 @@ use colored::{ColoredString, Colorize};
 use env_logger::{fmt::Formatter as LogFormatter, Builder as LogBuilder};
 use lazy_static::lazy_static;
 use log::{Level as LogLevel, LevelFilter as LogLevelFilter, Record as LogRecord};
-use reqwest::Url;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::Serialize;
 use std::{
     env,
     io::{self, Write},
@@ -99,19 +98,4 @@ lazy_static! {
     pub static ref LOG_PREFIX_ERROR: ColoredString = "E".red().bold();
     pub static ref LOG_PREFIX_TRACE: ColoredString = "T".normal();
     pub static ref LOG_PREFIX_INPUT: ColoredString = "*".blue().bold();
-}
-
-pub fn serialize_url<S>(value: &Url, serializer: S) -> std::result::Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(value.as_str())
-}
-
-pub fn deserialize_url<'de, D>(deserializer: D) -> std::result::Result<Url, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let url_string: String = Deserialize::deserialize(deserializer)?;
-    Url::parse(&url_string).map_err(|error| serde::de::Error::custom(error.to_string()))
 }


### PR DESCRIPTION
Add support for using an HTTP proxy for all requests. The proxy configuration is saved as part of the context.

Additionally, the proxy can be overridden / specified as a one off using a global command line argument `--proxy https://proxy.example` (e.g. similar to `--endpoint` / `--token`).

E.g.
```
re get comments // uses proxy from context
re --proxy http://112.78.165.190:8080 // overwrites the proxy from the context with the given one
````

To add a proxy to a context
```
re config add -n my-context --proxy http://myproxy.example
```

NB. When modifying a context interactively, the user is not asked about changing the proxy because I had to deal with it being an `Option<Option<<>>` and couldn't reuse the stdin input util and didn't bother.

I tried it out with online free HTTP proxies. **Don't use a token / context for a real account if you do this and reset it afterwards anyway** !!

For https://github.com/reinfer/platform/issues/10508

