### PR TITLE
cli: add bulk delete command

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -777,7 +777,7 @@ pub struct CommentsIter<'a> {
     to_timestamp: Option<DateTime<Utc>>,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CommentsIterTimerange {
     pub from: Option<DateTime<Utc>>,
     pub to: Option<DateTime<Utc>>,

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -120,6 +120,9 @@ pub struct Comment {
     #[serde(skip_serializing_if = "PropertyMap::is_empty", default)]
     pub user_properties: PropertyMap,
     pub created_at: DateTime<Utc>,
+
+    #[serde(default)]
+    pub has_annotations: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/api/src/resources/source.rs
+++ b/api/src/resources/source.rs
@@ -50,7 +50,7 @@ impl FromStr for FullName {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct Id(pub String);
 
 // TODO(mcobzarenco)[3963]: Make `Identifier` into a trait (ensure it still implements
@@ -70,6 +70,12 @@ impl From<Id> for Identifier {
 impl From<FullName> for Identifier {
     fn from(full_name: FullName) -> Self {
         Identifier::FullName(full_name)
+    }
+}
+
+impl<'a> From<&'a Source> for Identifier {
+    fn from(source: &Source) -> Self {
+        Identifier::FullName(source.full_name())
     }
 }
 

--- a/cli/src/commands/create/comments.rs
+++ b/cli/src/commands/create/comments.rs
@@ -517,11 +517,8 @@ fn progress_bar(
             basic_statistics
         },
         &statistics,
-        total_bytes,
-        ProgressOptions {
-            bytes_units: true,
-            ..Default::default()
-        },
+        Some(total_bytes),
+        ProgressOptions { bytes_units: true },
     )
 }
 

--- a/cli/src/commands/create/emails.rs
+++ b/cli/src/commands/create/emails.rs
@@ -195,10 +195,7 @@ fn progress_bar(total_bytes: u64, statistics: &Arc<Statistics>) -> Progress {
             )
         },
         &statistics,
-        total_bytes,
-        ProgressOptions {
-            bytes_units: true,
-            ..Default::default()
-        },
+        Some(total_bytes),
+        ProgressOptions { bytes_units: true },
     )
 }

--- a/cli/src/commands/delete.rs
+++ b/cli/src/commands/delete.rs
@@ -1,7 +1,18 @@
 use anyhow::{Context, Result};
-use log::info;
-use reinfer_client::{BucketIdentifier, Client, CommentId, DatasetIdentifier, SourceIdentifier};
+use chrono::{DateTime, Utc};
+use colored::Colorize;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use structopt::StructOpt;
+
+use reinfer_client::{
+    BucketIdentifier, Client, CommentId, CommentsIterTimerange, DatasetIdentifier, Source,
+    SourceIdentifier,
+};
+
+use crate::progress::{Options as ProgressOptions, Progress};
 
 #[derive(Debug, StructOpt)]
 pub enum DeleteArgs {
@@ -23,6 +34,35 @@ pub enum DeleteArgs {
         #[structopt(name = "comment id")]
         /// Ids of the comments to delete
         comments: Vec<CommentId>,
+    },
+
+    #[structopt(name = "bulk")]
+    /// Delete all comments in a given time range.
+    BulkComments {
+        #[structopt(short = "s", long = "source")]
+        /// Name or id of the source to delete comments from
+        source: SourceIdentifier,
+
+        #[structopt(long, parse(try_from_str))]
+        /// Whether to delete comments that are annotated in any of the datasets
+        /// containing this source.
+        /// Use --include-annotated=false to keep any annotated comments in the given range.
+        /// Use --include-annotated=true to delete all comments.
+        include_annotated: bool,
+
+        #[structopt(long)]
+        /// Starting timestamp for comments to delete (inclusive). Should be in
+        /// RFC 3339 format, e.g. 1970-01-02T03:04:05Z
+        from_timestamp: Option<DateTime<Utc>>,
+
+        #[structopt(long)]
+        /// Ending timestamp for comments to delete (inclusive). Should be in
+        /// RFC 3339 format, e.g. 1970-01-02T03:04:05Z
+        to_timestamp: Option<DateTime<Utc>>,
+
+        #[structopt(long)]
+        /// Don't display a progress bar
+        no_progress: bool,
     },
 
     #[structopt(name = "bucket")]
@@ -48,26 +88,169 @@ pub fn run(delete_args: &DeleteArgs, client: Client) -> Result<()> {
             client
                 .delete_source(source.clone())
                 .context("Operation to delete source has failed.")?;
-            info!("Deleted source.");
+            log::info!("Deleted source.");
         }
         DeleteArgs::Comments { source, comments } => {
             client
                 .delete_comments(source.clone(), comments)
                 .context("Operation to delete comments has failed.")?;
-            info!("Deleted comments.");
+            log::info!("Deleted comments.");
+        }
+        DeleteArgs::BulkComments {
+            source: source_identifier,
+            include_annotated,
+            from_timestamp,
+            to_timestamp,
+            no_progress,
+        } => {
+            let source = client.get_source(source_identifier.clone())?;
+            let show_progress = !no_progress;
+            delete_comments_in_period(
+                &client,
+                source,
+                *include_annotated,
+                CommentsIterTimerange {
+                    from: *from_timestamp,
+                    to: *to_timestamp,
+                },
+                show_progress,
+            )
+            .context("Operation to delete comments has failed.")?;
         }
         DeleteArgs::Dataset { dataset } => {
             client
                 .delete_dataset(dataset.clone())
                 .context("Operation to delete dataset has failed.")?;
-            info!("Deleted dataset.");
+            log::info!("Deleted dataset.");
         }
         DeleteArgs::Bucket { bucket } => {
             client
                 .delete_bucket(bucket.clone())
                 .context("Operation to delete bucket has failed.")?;
-            info!("Deleted bucket.");
+            log::info!("Deleted bucket.");
         }
     };
     Ok(())
+}
+
+fn delete_comments_in_period(
+    client: &Client,
+    source: Source,
+    include_annotated: bool,
+    timerange: CommentsIterTimerange,
+    show_progress: bool,
+) -> Result<()> {
+    log::info!(
+        "Deleting comments in source `{}`{} (include-annotated: {})",
+        source.full_name().0,
+        match (timerange.from, timerange.to) {
+            (None, None) => "".into(),
+            (Some(start), None) => format!(" after {}", start),
+            (None, Some(end)) => format!(" before {}", end),
+            (Some(start), Some(end)) => format!(" in range {} -> {}", start, end),
+        },
+        include_annotated,
+    );
+    let statistics = Arc::new(Statistics::new());
+    {
+        // Deleting comments in a block to ensure `_progress` is dropped before
+        // logging any further
+        let _progress = if show_progress {
+            Some(delete_comments_progress_bar(&statistics))
+        } else {
+            None
+        };
+        client
+            .get_comments_iter(&source.full_name(), None, timerange)
+            .try_for_each(|page| -> Result<()> {
+                let page = page.context("Operation to get comments failed")?;
+                let num_comments = page.len();
+                let comment_ids = page
+                    .into_iter()
+                    .filter_map(|comment| {
+                        if !include_annotated && comment.has_annotations {
+                            None
+                        } else {
+                            Some(comment.id)
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                let num_skipped = num_comments - comment_ids.len();
+                statistics.increment_skipped(num_skipped);
+
+                if comment_ids.is_empty() {
+                    return Ok(());
+                }
+
+                client
+                    .delete_comments(&source, &comment_ids)
+                    .context("Operation to delete comments failed")?;
+                statistics.increment_deleted(comment_ids.len());
+
+                Ok(())
+            })?;
+    }
+    log::info!(
+        "Deleted {} comments (skipped {}).",
+        statistics.deleted(),
+        statistics.skipped()
+    );
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct Statistics {
+    deleted: AtomicUsize,
+    skipped: AtomicUsize,
+}
+
+impl Statistics {
+    fn new() -> Self {
+        Self {
+            deleted: AtomicUsize::new(0),
+            skipped: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline]
+    fn increment_deleted(&self, num_deleted: usize) {
+        self.deleted.fetch_add(num_deleted, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn increment_skipped(&self, num_skipped: usize) {
+        self.skipped.fetch_add(num_skipped, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn deleted(&self) -> usize {
+        self.deleted.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn skipped(&self) -> usize {
+        self.skipped.load(Ordering::SeqCst)
+    }
+}
+
+fn delete_comments_progress_bar(statistics: &Arc<Statistics>) -> Progress {
+    Progress::new(
+        move |statistics| {
+            let num_deleted = statistics.deleted() as u64;
+            let num_skipped = statistics.skipped() as u64;
+            (
+                num_deleted + num_skipped,
+                format!(
+                    "{} {}{}",
+                    num_deleted.to_string().bold(),
+                    "deleted".dimmed(),
+                    format!(" [{} {}] total", num_skipped, "skipped".dimmed())
+                ),
+            )
+        },
+        &statistics,
+        None,
+        ProgressOptions { bytes_units: false },
+    )
 }

--- a/cli/src/commands/get.rs
+++ b/cli/src/commands/get.rs
@@ -668,10 +668,7 @@ fn get_comments_progress_bar(
             )
         },
         &statistics,
-        total_bytes,
-        ProgressOptions {
-            bytes_units: false,
-            ..Default::default()
-        },
+        Some(total_bytes),
+        ProgressOptions { bytes_units: false },
     )
 }

--- a/cli/tests/samples/many.jsonl
+++ b/cli/tests/samples/many.jsonl
@@ -1,0 +1,8 @@
+{"comment":{"id":"1","timestamp":"2020-01-01T00:00:00Z","messages":[{"body":{"text":"Comment 1"}}]}}
+{"comment":{"id":"2","timestamp":"2020-01-02T00:00:00Z","messages":[{"body":{"text":"Comment 2"}}]},"labelling":{"assigned":[{"name":"A","sentiment":"positive"}]}}
+{"comment":{"id":"3","timestamp":"2020-01-03T00:00:00Z","messages":[{"body":{"text":"Comment 3"}}]},"labelling":{"assigned":[{"name":"A","sentiment":"positive"}]}}
+{"comment":{"id":"4","timestamp":"2020-01-04T00:00:00Z","messages":[{"body":{"text":"Comment 4"}}]},"labelling":{"assigned":[{"name":"B","sentiment":"positive"}]}}
+{"comment":{"id":"5","timestamp":"2020-02-01T00:00:00Z","messages":[{"body":{"text":"Comment 5"}}]}}
+{"comment":{"id":"6","timestamp":"2020-02-02T00:00:00Z","messages":[{"body":{"text":"Comment 6"}}]},"labelling":{"assigned":[{"name":"C","sentiment":"positive"}]}}
+{"comment":{"id":"7","timestamp":"2020-02-03T00:00:00Z","messages":[{"body":{"text":"Comment 7"}}]},"labelling":{"assigned":[{"name":"A","sentiment":"positive"}]}}
+{"comment":{"id":"8","timestamp":"2020-02-04T00:00:00Z","messages":[{"body":{"text":"Comment 8"}}]},"labelling":{"assigned":[{"name":"B","sentiment":"positive"}]}}

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -1,0 +1,132 @@
+use reinfer_client::Dataset;
+use uuid::Uuid;
+
+use crate::{TestCli, TestSource};
+
+pub struct TestDataset {
+    full_name: String,
+    sep_index: usize,
+}
+
+impl TestDataset {
+    pub fn new() -> Self {
+        let cli = TestCli::get();
+        let user = TestCli::organisation();
+        let full_name = format!("{}/test-dataset-{}", user, Uuid::new_v4());
+        let sep_index = user.len();
+
+        let output = cli.run(&["create", "dataset", &full_name]);
+        assert!(output.is_empty());
+
+        Self {
+            full_name,
+            sep_index,
+        }
+    }
+
+    pub fn new_args(args: &[&str]) -> Self {
+        let cli = TestCli::get();
+        let user = TestCli::organisation();
+        let full_name = format!("{}/test-dataset-{}", user, Uuid::new_v4());
+        let sep_index = user.len();
+
+        let output = cli.run(["create", "dataset", &full_name].iter().chain(args));
+        assert!(output.is_empty());
+
+        Self {
+            full_name,
+            sep_index,
+        }
+    }
+
+    pub fn identifier(&self) -> &str {
+        &self.full_name
+    }
+
+    pub fn owner(&self) -> &str {
+        &self.full_name[..self.sep_index]
+    }
+
+    pub fn name(&self) -> &str {
+        &self.full_name[self.sep_index + 1..]
+    }
+}
+
+impl Drop for TestDataset {
+    fn drop(&mut self) {
+        let output = TestCli::get().run(&["delete", "dataset", self.identifier()]);
+        assert!(output.is_empty());
+    }
+}
+
+#[test]
+fn test_test_dataset() {
+    let cli = TestCli::get();
+    let dataset = TestDataset::new();
+
+    let identifier = dataset.identifier().to_owned();
+
+    let output = cli.run(&["get", "datasets"]);
+    assert!(output.contains(&identifier));
+
+    drop(dataset);
+
+    // RAII TestDataset; should automatically clean up the temporary dataset on drop.
+    let output = cli.run(&["get", "datasets"]);
+    assert!(!output.contains(&identifier));
+}
+
+#[test]
+fn test_list_multiple_datasets() {
+    let cli = TestCli::get();
+    let dataset1 = TestDataset::new();
+    let dataset2 = TestDataset::new();
+
+    let output = cli.run(&["get", "datasets"]);
+    assert!(output.contains(dataset1.identifier()));
+    assert!(output.contains(dataset2.identifier()));
+
+    let output = cli.run(&["get", "datasets", dataset1.identifier()]);
+    assert!(output.contains(dataset1.identifier()));
+    assert!(!output.contains(dataset2.identifier()));
+
+    let output = cli.run(&["get", "datasets", dataset2.identifier()]);
+    assert!(!output.contains(dataset1.identifier()));
+    assert!(output.contains(dataset2.identifier()));
+}
+
+#[test]
+fn test_create_dataset_custom() {
+    let cli = TestCli::get();
+    let source = TestSource::new();
+
+    let dataset = TestDataset::new_args(&[
+        "--title=some title",
+        "--description=some description",
+        &format!("--source={}", source.identifier()),
+        "--has-sentiment=true",
+    ]);
+
+    let output = cli.run(&["get", "datasets", dataset.identifier(), "--output=json"]);
+    let dataset_info: Dataset = serde_json::from_str(&output).unwrap();
+
+    assert_eq!(&dataset_info.owner.0, dataset.owner());
+    assert_eq!(&dataset_info.name.0, dataset.name());
+    assert_eq!(dataset_info.title, "some title");
+    assert_eq!(dataset_info.description, "some description");
+    assert_eq!(dataset_info.source_ids.len(), 1);
+    assert_eq!(dataset_info.has_sentiment, true);
+}
+
+#[test]
+fn test_create_dataset_requires_owner() {
+    let cli = TestCli::get();
+
+    let output = cli
+        .command()
+        .args(&["create", "dataset", "dataset-without-owner"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+}

--- a/cli/tests/tests.rs
+++ b/cli/tests/tests.rs
@@ -2,7 +2,9 @@ mod common;
 
 mod test_buckets;
 mod test_comments;
+mod test_datasets;
 mod test_sources;
 
 use common::TestCli;
+use test_datasets::TestDataset;
 use test_sources::TestSource;


### PR DESCRIPTION
Adds a new CLI command for deleting comments in bulk in a source. 

Example usage to delete all unannotated comments in the (inclusive) range `2015-01-01T00:00:00Z` -> `2017-07-30T00:00:00Z`.
```
re delete bulk --source org/delete-me --from-timestamp 2015-01-01T00:00:00Z --to-timestamp 2017-07-30T00:00:00Z
```
By default, comments that are annotated in any dataset containing the source are NOT deleted. Note that only datasets visible to the user account making the request are considered. To delete annotated comments as well, use the `--include-annotated` flag (has to be `=true`)
```
re delete bulk --source org/delete-me --from-timestamp 2015-01-01T00:00:00Z --to-timestamp 2017-07-30T00:00:00Z --include-annotated=true
```

---

Notes:
  - I called everything "annotations" / "annotated" instead of "reviewed", as that's the new name we're using these days, although "reviewed" is  still used in the CLI when getting comments e.g. `--reviewed-only`
  - We are a bit inconsistent with when a flag can be used by itself without a value, e.g. `--no-progress`  whereas in some places we  need an explicit truth value, e.g. `include-predictions=true`, `--has-sentiment=true`, `--should-translate=false`. Defo prefer the latter, but I added a `--no-progress` flag without a value for consistency, e.g. `re delete bulk --include-annotated=true --no-progress ...`
  
---

Demo:

![Peek 2021-03-05 14-44](https://user-images.githubusercontent.com/797170/110130810-5ac5ba80-7dc1-11eb-9186-04b844c862ac.gif)

^ deleting all unreviewed comments followed by deleting all comments ^

For reinfer/platform#9757