### PR TITLE
cli: update dataset/source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Changed
 
- - When uploading annotated comments, empty lists of assigned / dismissed labels
-   are serialized in the request. Previously empty lists were skipped which
-   meant it was not possible to remove labellings (N.B. the API distinguishes
-   between missing field -- labellings are unmodified -- or and empty list --
-   labellings are removed).
+- When uploading annotated comments, empty lists of assigned / dismissed labels
+  are serialized in the request. Previously empty lists were skipped which
+  meant it was not possible to remove labellings (N.B. the API distinguishes
+  between missing field -- labellings are unmodified -- or and empty list --
+  labellings are removed).
 
+## Added
+
+- `update source`: update an existing source
+- `update dataset`: update an existing dataset
 
 # v0.6.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +259,22 @@ checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "difference"
@@ -821,6 +846,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +903,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "prettytable-rs"
@@ -1042,6 +1088,7 @@ dependencies = [
  "log",
  "maplit",
  "once_cell",
+ "pretty_assertions",
  "prettytable-rs",
  "regex",
  "reinfer-client",

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -28,11 +28,13 @@ use crate::resources::{
     dataset::{
         CreateRequest as CreateDatasetRequest, CreateResponse as CreateDatasetResponse,
         GetAvailableResponse as GetAvailableDatasetsResponse, GetResponse as GetDatasetResponse,
+        UpdateRequest as UpdateDatasetRequest, UpdateResponse as UpdateDatasetResponse,
     },
     email::{PutEmailsRequest, PutEmailsResponse},
     source::{
         CreateRequest as CreateSourceRequest, CreateResponse as CreateSourceResponse,
         GetAvailableResponse as GetAvailableSourcesResponse, GetResponse as GetSourceResponse,
+        UpdateRequest as UpdateSourceRequest, UpdateResponse as UpdateSourceResponse,
     },
     statistics::GetResponse as GetStatisticsResponse,
     trigger::{
@@ -64,12 +66,12 @@ pub use crate::{
         },
         dataset::{
             Dataset, FullName as DatasetFullName, Id as DatasetId, Identifier as DatasetIdentifier,
-            Name as DatasetName, NewDataset,
+            Name as DatasetName, NewDataset, UpdateDataset,
         },
         email::{Id as EmailId, Mailbox, MimeContent, NewEmail},
         source::{
             FullName as SourceFullName, Id as SourceId, Identifier as SourceIdentifier,
-            Name as SourceName, NewSource, Source,
+            Name as SourceName, NewSource, Source, UpdateSource,
         },
         statistics::Statistics,
         trigger::{
@@ -189,6 +191,21 @@ impl Client {
             .put::<_, _, CreateSourceResponse, SimpleApiError>(
                 self.endpoints.source_by_name(&source_name)?,
                 CreateSourceRequest { source: options },
+            )?
+            .source)
+    }
+
+    /// Update a source.
+    pub fn update_source(
+        &self,
+        source_name: &SourceFullName,
+        options: UpdateSource,
+    ) -> Result<Source> {
+        Ok(self
+            .post::<_, _, UpdateSourceResponse, SimpleApiError>(
+                self.endpoints.source_by_name(&source_name)?,
+                UpdateSourceRequest { source: options },
+                Retry::Yes,
             )?
             .source)
     }
@@ -353,6 +370,7 @@ impl Client {
         })
     }
 
+    /// Create a dataset.
     pub fn create_dataset(
         &self,
         dataset_name: &DatasetFullName,
@@ -362,6 +380,21 @@ impl Client {
             .put::<_, _, CreateDatasetResponse, SimpleApiError>(
                 self.endpoints.dataset_by_name(dataset_name)?,
                 CreateDatasetRequest { dataset: options },
+            )?
+            .dataset)
+    }
+
+    /// Update a dataset.
+    pub fn update_dataset(
+        &self,
+        dataset_name: &DatasetFullName,
+        options: UpdateDataset,
+    ) -> Result<Dataset> {
+        Ok(self
+            .post::<_, _, UpdateDatasetResponse, SimpleApiError>(
+                self.endpoints.dataset_by_name(dataset_name)?,
+                UpdateDatasetRequest { dataset: options },
+                Retry::Yes,
             )?
             .dataset)
     }

--- a/api/src/resources/source.rs
+++ b/api/src/resources/source.rs
@@ -120,6 +120,9 @@ pub struct NewSource<'request> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bucket_id: Option<BucketId>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sensitive_properties: Option<Vec<&'request str>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -139,5 +142,33 @@ pub(crate) struct GetAvailableResponse {
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct GetResponse {
+    pub source: Source,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateSource<'request> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<&'request str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<&'request str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub should_translate: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bucket_id: Option<BucketId>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sensitive_properties: Option<Vec<&'request str>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct UpdateRequest<'request> {
+    pub source: UpdateSource<'request>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct UpdateResponse {
     pub source: Source,
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,6 +38,7 @@ url = { version = "2.2.2", features = ["serde"] }
 reinfer-client = { version = "0.6.0", path = "../api" }
 
 [dev-dependencies]
+pretty_assertions = "0.7.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [features]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,4 +1,6 @@
-use crate::commands::{config::ConfigArgs, create::CreateArgs, delete::DeleteArgs, get::GetArgs};
+use crate::commands::{
+    config::ConfigArgs, create::CreateArgs, delete::DeleteArgs, get::GetArgs, update::UpdateArgs,
+};
 use anyhow::{anyhow, Error, Result};
 use reqwest::Url;
 use std::{path::PathBuf, str::FromStr};
@@ -65,6 +67,13 @@ pub enum Command {
     Create {
         #[structopt(subcommand)]
         create_args: CreateArgs,
+    },
+
+    #[structopt(name = "update")]
+    /// Update existing resources
+    Update {
+        #[structopt(subcommand)]
+        update_args: UpdateArgs,
     },
 
     #[structopt(name = "delete")]

--- a/cli/src/commands/create/dataset.rs
+++ b/cli/src/commands/create/dataset.rs
@@ -1,29 +1,15 @@
 use anyhow::{Context, Result};
 use log::info;
-use once_cell::sync::Lazy;
-use regex::Regex;
 use reinfer_client::{
     resources::dataset::EntityDefs, Client, DatasetFullName, NewDataset, SourceIdentifier,
 };
 use structopt::StructOpt;
 
-static RX_FULL_NAME: Lazy<Regex> =
-    Lazy::new(|| Regex::new("^[A-Za-z0-9-_.]{1,1024}/[A-Za-z0-9-_]{1,256}").unwrap());
-
-/// Ensures the name provided conforms to the <owner>/<name> structure
-fn validate_dataset_name(s: String) -> Result<(), String> {
-    if !RX_FULL_NAME.is_match(&s) {
-        return Err(s);
-    }
-
-    Ok(())
-}
-
 #[derive(Debug, StructOpt)]
 pub struct CreateDatasetArgs {
-    #[structopt(name = "owner-name/dataset-name", validator = validate_dataset_name)]
+    #[structopt(name = "owner-name/dataset-name")]
     /// Full name of the new dataset <owner>/<name>
-    name: String,
+    name: DatasetFullName,
 
     #[structopt(long = "title")]
     /// Set the title of the new dataset
@@ -81,7 +67,7 @@ pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
 
     let dataset = client
         .create_dataset(
-            &DatasetFullName(name.clone()),
+            name,
             NewDataset {
                 source_ids: &source_ids,
                 title: title.as_deref(),

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod create;
 pub mod delete;
 pub mod get;
+pub mod update;
 
 use anyhow::{anyhow, Error, Result};
 use std::str::FromStr;

--- a/cli/src/commands/update/dataset.rs
+++ b/cli/src/commands/update/dataset.rs
@@ -1,0 +1,70 @@
+use anyhow::{Context, Result};
+use log::info;
+use reinfer_client::{Client, DatasetIdentifier, SourceId, SourceIdentifier, UpdateDataset};
+use structopt::StructOpt;
+
+/// Update a dataset.
+#[derive(Debug, StructOpt)]
+pub struct UpdateDatasetArgs {
+    #[structopt(name = "dataset")]
+    /// Name or id of the dataset to delete
+    dataset: DatasetIdentifier,
+
+    #[structopt(long = "title")]
+    /// Set the title of the dataset
+    title: Option<String>,
+
+    #[structopt(long = "description")]
+    /// Set the description of the dataset
+    description: Option<String>,
+
+    #[structopt(short = "s", long = "source")]
+    /// Names or ids of the sources in the dataset
+    sources: Option<Vec<SourceIdentifier>>,
+}
+
+pub fn update(client: &Client, args: &UpdateDatasetArgs) -> Result<()> {
+    let UpdateDatasetArgs {
+        ref dataset,
+        ref title,
+        ref description,
+        ref sources,
+    } = *args;
+
+    let source_ids = sources
+        .as_ref()
+        .map::<Result<Vec<SourceId>>, _>(|sources| {
+            sources
+                .iter()
+                .map(|source| Ok(client.get_source(source.clone())?.id))
+                .collect()
+        })
+        .transpose()
+        .context("Operation to get sources failed")?;
+
+    let dataset_full_name = match dataset.to_owned() {
+        DatasetIdentifier::FullName(name) => name,
+        dataset @ DatasetIdentifier::Id(_) => client
+            .get_dataset(dataset)
+            .context("Fetching dataset id.")?
+            .full_name(),
+    };
+
+    let dataset = client
+        .update_dataset(
+            &dataset_full_name,
+            UpdateDataset {
+                source_ids: source_ids.as_deref(),
+                title: title.as_deref(),
+                description: description.as_deref(),
+            },
+        )
+        .context("Operation to update a dataset has failed.")?;
+    info!(
+        "Dataset `{}` [id: {}] updated successfully",
+        dataset.full_name().0,
+        dataset.id.0,
+    );
+
+    Ok(())
+}

--- a/cli/src/commands/update/mod.rs
+++ b/cli/src/commands/update/mod.rs
@@ -1,0 +1,25 @@
+mod dataset;
+mod source;
+
+use self::{dataset::UpdateDatasetArgs, source::UpdateSourceArgs};
+use anyhow::Result;
+use reinfer_client::Client;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub enum UpdateArgs {
+    #[structopt(name = "source")]
+    /// Update a new source
+    Source(UpdateSourceArgs),
+
+    #[structopt(name = "dataset")]
+    /// Update a new dataset
+    Dataset(UpdateDatasetArgs),
+}
+
+pub fn run(update_args: &UpdateArgs, client: Client) -> Result<()> {
+    match update_args {
+        UpdateArgs::Source(source_args) => source::update(&client, source_args),
+        UpdateArgs::Dataset(dataset_args) => dataset::update(&client, dataset_args),
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,7 +16,7 @@ use structopt::{clap::Shell as ClapShell, StructOpt};
 
 use crate::{
     args::{Args, Command, Shell},
-    commands::{config as config_command, create, delete, get},
+    commands::{config as config_command, create, delete, get, update},
     config::ReinferConfig,
 };
 
@@ -43,6 +43,9 @@ fn run(args: Args) -> Result<()> {
         }
         Command::Create { ref create_args } => {
             create::run(create_args, client_from_args(&args, &config)?)
+        }
+        Command::Update { ref update_args } => {
+            update::run(update_args, client_from_args(&args, &config)?)
         }
     }
 }


### PR DESCRIPTION
Add cli and api constructs to allow updating sources and datasets.

As well as just increasing coverage of our API, we need this for `gpt-data-generator` internally.