### PR TITLE
api/cli: get comment by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - More public types implement `Serialize`, `Eq` and `Hash` for downstream use.
 
+## Added
+
+- `get comment`: get a single comment by source and id
+
 # v0.7.0
 
 ## Breaking

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -111,6 +111,11 @@ pub struct SyncCommentsResponse {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct GetCommentResponse {
+    pub comment: Comment,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Comment {
     pub id: Id,
     pub uid: Uid,


### PR DESCRIPTION
Allows fetching a single comment by id. Added for `gpt-data-generator`, but also exposed in the cli as a useful tool for end users.