### PR TITLE
cli: refactor data printing, print on create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Breaking
 
 - All API resources with floats now use `ordered_float::NotNan`
+- A new top level flag `-o/--output` has been added. This replaces all previous `-o/--output` flags in the `re get *` subcommands.
 
 ## Changed
 
@@ -11,6 +12,8 @@
 ## Added
 
 - `get comment`: get a single comment by source and id
+- Created or updated resources will be returned via stdout. The format of the output can be changed with the global `-o/--output` flag.
+  - This excludes creation of the `comments` and `emails` resources.
 
 # v0.7.0
 

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,5 +1,9 @@
-use crate::commands::{
-    config::ConfigArgs, create::CreateArgs, delete::DeleteArgs, get::GetArgs, update::UpdateArgs,
+use crate::{
+    commands::{
+        config::ConfigArgs, create::CreateArgs, delete::DeleteArgs, get::GetArgs,
+        update::UpdateArgs,
+    },
+    printer::OutputFormat,
 };
 use anyhow::{anyhow, Error, Result};
 use reqwest::Url;
@@ -43,6 +47,12 @@ pub struct Args {
     #[structopt(long = "proxy")]
     /// URL for an HTTP proxy that will be used for all requests if specified
     pub proxy: Option<Url>,
+
+    #[structopt(short = "o", long = "output", default_value = "table")]
+    /// Output format. One of: json, table
+    ///
+    /// Output is provided in table format on stdout by default.
+    pub output: OutputFormat,
 
     #[structopt(subcommand)]
     pub command: Command,

--- a/cli/src/commands/create/bucket.rs
+++ b/cli/src/commands/create/bucket.rs
@@ -1,3 +1,4 @@
+use crate::printer::Printer;
 use anyhow::{Context, Result};
 use log::info;
 use reinfer_client::{BucketFullName, BucketType, Client, NewBucket, TransformTag};
@@ -23,7 +24,7 @@ pub struct CreateBucketArgs {
     transform_tag: TransformTag,
 }
 
-pub fn create(client: &Client, args: &CreateBucketArgs) -> Result<()> {
+pub fn create(client: &Client, args: &CreateBucketArgs, printer: &Printer) -> Result<()> {
     let CreateBucketArgs {
         ref name,
         ref title,
@@ -46,5 +47,6 @@ pub fn create(client: &Client, args: &CreateBucketArgs) -> Result<()> {
         bucket.full_name(),
         bucket.id
     );
+    printer.print_resources(&[bucket])?;
     Ok(())
 }

--- a/cli/src/commands/create/dataset.rs
+++ b/cli/src/commands/create/dataset.rs
@@ -1,3 +1,4 @@
+use crate::printer::Printer;
 use anyhow::{Context, Result};
 use log::info;
 use reinfer_client::{
@@ -40,7 +41,7 @@ pub struct CreateDatasetArgs {
     copy_annotations_from: Option<String>,
 }
 
-pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
+pub fn create(client: &Client, args: &CreateDatasetArgs, printer: &Printer) -> Result<()> {
     let CreateDatasetArgs {
         ref name,
         ref title,
@@ -88,6 +89,6 @@ pub fn create(client: &Client, args: &CreateDatasetArgs) -> Result<()> {
         dataset.full_name().0,
         dataset.id.0,
     );
-
+    printer.print_resources(&[dataset])?;
     Ok(())
 }

--- a/cli/src/commands/create/mod.rs
+++ b/cli/src/commands/create/mod.rs
@@ -9,6 +9,7 @@ use self::{
     bucket::CreateBucketArgs, comments::CreateCommentsArgs, dataset::CreateDatasetArgs,
     emails::CreateEmailsArgs, source::CreateSourceArgs, user::CreateUserArgs,
 };
+use crate::printer::Printer;
 use anyhow::Result;
 use reinfer_client::Client;
 use structopt::StructOpt;
@@ -40,13 +41,13 @@ pub enum CreateArgs {
     User(CreateUserArgs),
 }
 
-pub fn run(create_args: &CreateArgs, client: Client) -> Result<()> {
+pub fn run(create_args: &CreateArgs, client: Client, printer: &Printer) -> Result<()> {
     match create_args {
-        CreateArgs::Bucket(bucket_args) => bucket::create(&client, bucket_args),
-        CreateArgs::Source(source_args) => source::create(&client, source_args),
-        CreateArgs::Dataset(dataset_args) => dataset::create(&client, dataset_args),
+        CreateArgs::Bucket(bucket_args) => bucket::create(&client, bucket_args, printer),
+        CreateArgs::Source(source_args) => source::create(&client, source_args, printer),
+        CreateArgs::Dataset(dataset_args) => dataset::create(&client, dataset_args, printer),
         CreateArgs::Comments(comments_args) => comments::create(&client, comments_args),
         CreateArgs::Emails(emails_args) => emails::create(&client, emails_args),
-        CreateArgs::User(user_args) => user::create(&client, user_args),
+        CreateArgs::User(user_args) => user::create(&client, user_args, printer),
     }
 }

--- a/cli/src/commands/create/source.rs
+++ b/cli/src/commands/create/source.rs
@@ -1,3 +1,4 @@
+use crate::printer::Printer;
 use anyhow::{Context, Result};
 use log::info;
 use reinfer_client::{BucketId, BucketIdentifier, Client, NewSource, SourceFullName};
@@ -30,7 +31,7 @@ pub struct CreateSourceArgs {
     bucket: Option<BucketIdentifier>,
 }
 
-pub fn create(client: &Client, args: &CreateSourceArgs) -> Result<()> {
+pub fn create(client: &Client, args: &CreateSourceArgs, printer: &Printer) -> Result<()> {
     let CreateSourceArgs {
         ref name,
         ref title,
@@ -74,5 +75,6 @@ pub fn create(client: &Client, args: &CreateSourceArgs) -> Result<()> {
         source.full_name().0,
         source.id.0
     );
+    printer.print_resources(&[source])?;
     Ok(())
 }

--- a/cli/src/commands/create/user.rs
+++ b/cli/src/commands/create/user.rs
@@ -1,3 +1,4 @@
+use crate::printer::Printer;
 use anyhow::{anyhow, Context, Result};
 use log::info;
 use reinfer_client::{
@@ -29,7 +30,7 @@ pub struct CreateUserArgs {
     organisation_permissions_list: Vec<OrganisationPermission>,
 }
 
-pub fn create(client: &Client, args: &CreateUserArgs) -> Result<()> {
+pub fn create(client: &Client, args: &CreateUserArgs, printer: &Printer) -> Result<()> {
     let CreateUserArgs {
         ref username,
         ref email,
@@ -64,6 +65,6 @@ pub fn create(client: &Client, args: &CreateUserArgs) -> Result<()> {
         "New user `{}` with email `{}` [id: {}] created successfully",
         user.username.0, user.email.0, user.id.0
     );
-
+    printer.print_resources(&[user])?;
     Ok(())
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3,32 +3,3 @@ pub mod create;
 pub mod delete;
 pub mod get;
 pub mod update;
-
-use anyhow::{anyhow, Error, Result};
-use std::str::FromStr;
-
-#[derive(Copy, Clone, Debug)]
-pub enum OutputFormat {
-    Json,
-    Table,
-}
-
-impl Default for OutputFormat {
-    fn default() -> Self {
-        OutputFormat::Table
-    }
-}
-
-impl FromStr for OutputFormat {
-    type Err = Error;
-
-    fn from_str(string: &str) -> Result<Self> {
-        if string == "table" {
-            Ok(OutputFormat::Table)
-        } else if string == "json" {
-            Ok(OutputFormat::Json)
-        } else {
-            Err(anyhow!("{}", string))
-        }
-    }
-}

--- a/cli/src/commands/update/dataset.rs
+++ b/cli/src/commands/update/dataset.rs
@@ -1,3 +1,4 @@
+use crate::printer::Printer;
 use anyhow::{Context, Result};
 use log::info;
 use reinfer_client::{Client, DatasetIdentifier, SourceId, SourceIdentifier, UpdateDataset};
@@ -23,7 +24,7 @@ pub struct UpdateDatasetArgs {
     sources: Option<Vec<SourceIdentifier>>,
 }
 
-pub fn update(client: &Client, args: &UpdateDatasetArgs) -> Result<()> {
+pub fn update(client: &Client, args: &UpdateDatasetArgs, printer: &Printer) -> Result<()> {
     let UpdateDatasetArgs {
         ref dataset,
         ref title,
@@ -65,6 +66,6 @@ pub fn update(client: &Client, args: &UpdateDatasetArgs) -> Result<()> {
         dataset.full_name().0,
         dataset.id.0,
     );
-
+    printer.print_resources(&[dataset])?;
     Ok(())
 }

--- a/cli/src/commands/update/mod.rs
+++ b/cli/src/commands/update/mod.rs
@@ -2,6 +2,7 @@ mod dataset;
 mod source;
 
 use self::{dataset::UpdateDatasetArgs, source::UpdateSourceArgs};
+use crate::printer::Printer;
 use anyhow::Result;
 use reinfer_client::Client;
 use structopt::StructOpt;
@@ -17,9 +18,9 @@ pub enum UpdateArgs {
     Dataset(UpdateDatasetArgs),
 }
 
-pub fn run(update_args: &UpdateArgs, client: Client) -> Result<()> {
+pub fn run(update_args: &UpdateArgs, client: Client, printer: &Printer) -> Result<()> {
     match update_args {
-        UpdateArgs::Source(source_args) => source::update(&client, source_args),
-        UpdateArgs::Dataset(dataset_args) => dataset::update(&client, dataset_args),
+        UpdateArgs::Source(source_args) => source::update(&client, source_args, printer),
+        UpdateArgs::Dataset(dataset_args) => dataset::update(&client, dataset_args, printer),
     }
 }

--- a/cli/src/commands/update/source.rs
+++ b/cli/src/commands/update/source.rs
@@ -1,3 +1,4 @@
+use crate::printer::Printer;
 use anyhow::{Context, Result};
 use log::info;
 use reinfer_client::{BucketId, BucketIdentifier, Client, SourceIdentifier, UpdateSource};
@@ -26,7 +27,7 @@ pub struct UpdateSourceArgs {
     bucket: Option<BucketIdentifier>,
 }
 
-pub fn update(client: &Client, args: &UpdateSourceArgs) -> Result<()> {
+pub fn update(client: &Client, args: &UpdateSourceArgs, printer: &Printer) -> Result<()> {
     let UpdateSourceArgs {
         ref source,
         ref title,
@@ -76,5 +77,6 @@ pub fn update(client: &Client, args: &UpdateSourceArgs) -> Result<()> {
         source.full_name().0,
         source.id.0
     );
+    printer.print_resources(&[source])?;
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,6 +2,7 @@
 mod args;
 mod commands;
 mod config;
+mod printer;
 mod progress;
 mod utils;
 
@@ -18,11 +19,13 @@ use crate::{
     args::{Args, Command, Shell},
     commands::{config as config_command, create, delete, get, update},
     config::ReinferConfig,
+    printer::Printer,
 };
 
 fn run(args: Args) -> Result<()> {
     let config_path = find_configuration(&args)?;
     let config = config::read_reinfer_config(&config_path)?;
+    let printer = Printer::new(args.output);
 
     match args.command {
         Command::Config { ref config_args } => {
@@ -37,15 +40,17 @@ fn run(args: Args) -> Result<()> {
             app.gen_completions_to("re", clap_shell, &mut io::stdout());
             Ok(())
         }
-        Command::Get { ref get_args } => get::run(get_args, client_from_args(&args, &config)?),
+        Command::Get { ref get_args } => {
+            get::run(get_args, client_from_args(&args, &config)?, &printer)
+        }
         Command::Delete { ref delete_args } => {
             delete::run(delete_args, client_from_args(&args, &config)?)
         }
         Command::Create { ref create_args } => {
-            create::run(create_args, client_from_args(&args, &config)?)
+            create::run(create_args, client_from_args(&args, &config)?, &printer)
         }
         Command::Update { ref update_args } => {
-            update::run(update_args, client_from_args(&args, &config)?)
+            update::run(update_args, client_from_args(&args, &config)?, &printer)
         }
     }
 }

--- a/cli/src/printer.rs
+++ b/cli/src/printer.rs
@@ -1,0 +1,208 @@
+use colored::Colorize;
+use prettytable::{cell, format, row, Row, Table};
+use reinfer_client::{Bucket, Dataset, Source, Trigger, User};
+use serde::Serialize;
+
+use anyhow::{anyhow, Context, Error, Result};
+use std::{
+    io::{self, Write},
+    str::FromStr,
+};
+
+pub fn print_resources_as_json<Resource>(
+    resources: impl IntoIterator<Item = Resource>,
+    mut writer: impl Write,
+) -> Result<()>
+where
+    Resource: Serialize,
+{
+    for resource in resources {
+        serde_json::to_writer(&mut writer, &resource)
+            .context("Could not serialise resource.")
+            .and_then(|_| writeln!(writer).context("Failed to write JSON resource to writer."))?;
+    }
+    Ok(())
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum OutputFormat {
+    Json,
+    Table,
+}
+
+impl Default for OutputFormat {
+    fn default() -> Self {
+        OutputFormat::Table
+    }
+}
+
+impl FromStr for OutputFormat {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self> {
+        if string == "table" {
+            Ok(OutputFormat::Table)
+        } else if string == "json" {
+            Ok(OutputFormat::Json)
+        } else {
+            Err(anyhow!("{}", string))
+        }
+    }
+}
+
+/// Represents a resource that is able to be displayed as a table.
+///
+/// The implementation must implement `to_table_headers` to return headers for the resource type,
+/// and `to_table_row`, which should return a data row for the given resource instance.
+pub trait DisplayTable {
+    fn to_table_headers() -> Row;
+
+    fn to_table_row(&self) -> Row;
+}
+
+impl DisplayTable for Bucket {
+    fn to_table_headers() -> Row {
+        row![bFg => "Name", "ID", "Created (UTC)", "Updated (UTC)", "Transform Tag"]
+    }
+
+    fn to_table_row(&self) -> Row {
+        let full_name = format!("{}{}{}", self.owner.0.dimmed(), "/".dimmed(), self.name.0);
+        row![
+            full_name,
+            self.id.0,
+            self.created_at.format("%Y-%m-%d %H:%M:%S"),
+            self.updated_at.format("%Y-%m-%d %H:%M:%S"),
+            match &self.transform_tag {
+                Some(transform_tag) => transform_tag.0.as_str().into(),
+                None => "missing".dimmed(),
+            }
+        ]
+    }
+}
+
+impl DisplayTable for Dataset {
+    fn to_table_headers() -> Row {
+        row![bFg => "Name", "ID", "Updated (UTC)", "Title"]
+    }
+
+    fn to_table_row(&self) -> Row {
+        let full_name = format!("{}{}{}", self.owner.0.dimmed(), "/".dimmed(), self.name.0);
+        row![
+            full_name,
+            self.id.0,
+            self.updated_at.format("%Y-%m-%d %H:%M:%S"),
+            self.title
+        ]
+    }
+}
+
+impl DisplayTable for Source {
+    fn to_table_headers() -> Row {
+        row![bFg => "Name", "ID", "Updated (UTC)", "Title"]
+    }
+
+    fn to_table_row(&self) -> Row {
+        let full_name = format!("{}{}{}", self.owner.0.dimmed(), "/".dimmed(), self.name.0);
+        row![
+            full_name,
+            self.id.0,
+            self.updated_at.format("%Y-%m-%d %H:%M:%S"),
+            self.title
+        ]
+    }
+}
+
+impl DisplayTable for Trigger {
+    fn to_table_headers() -> Row {
+        row![bFg => "Name", "ID", "Updated (UTC)", "Title"]
+    }
+
+    fn to_table_row(&self) -> Row {
+        row![
+            self.name.0,
+            self.id.0,
+            self.updated_at.format("%Y-%m-%d %H:%M:%S"),
+            self.title
+        ]
+    }
+}
+
+impl DisplayTable for User {
+    fn to_table_headers() -> Row {
+        row![bFg => "Name", "Email", "ID", "Created (UTC)"]
+    }
+
+    fn to_table_row(&self) -> Row {
+        row![
+            self.username.0,
+            self.email.0,
+            self.id.0,
+            self.created_at.format("%Y-%m-%d %H:%M:%S"),
+        ]
+    }
+}
+
+/// Helper trait to allow collection of resources to be converted into a table.
+pub trait IntoTable {
+    fn into_table(self) -> Table;
+}
+
+/// All iterators of resources can be converted into a table.
+impl<'a, Iterable, Item: 'a> IntoTable for Iterable
+where
+    Iterable: IntoIterator<Item = &'a Item>,
+    Item: DisplayTable,
+{
+    fn into_table(self) -> Table {
+        let mut table = new_table();
+        table.set_titles(Item::to_table_headers());
+        for source in self.into_iter() {
+            table.add_row(source.to_table_row());
+        }
+        table
+    }
+}
+
+fn new_table() -> Table {
+    let mut table = Table::new();
+    let format = format::FormatBuilder::new()
+        .column_separator(' ')
+        .borders(' ')
+        .separators(&[], format::LineSeparator::new('-', '+', '+', '+'))
+        .padding(0, 1)
+        .build();
+    table.set_format(format);
+    table
+}
+
+fn print_table<T: IntoTable>(resources: T) {
+    let table = resources.into_table();
+    table.printstd();
+}
+
+/// Print resources using the selected output format.
+///
+/// Resources passed to the printer must be able to be formatted using all supported
+/// `OutputFormat`s.
+#[derive(Default, Debug)]
+pub struct Printer {
+    output: OutputFormat,
+}
+
+impl Printer {
+    pub fn new(output: OutputFormat) -> Self {
+        Self { output }
+    }
+
+    pub fn print_resources<T, Resource>(&self, resources: T) -> Result<()>
+    where
+        T: IntoIterator<Item = Resource> + IntoTable,
+        Resource: Serialize,
+    {
+        match self.output {
+            OutputFormat::Table => print_table(resources),
+            OutputFormat::Json => print_resources_as_json(resources, io::stdout().lock())?,
+        };
+        Ok(())
+    }
+}

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -3,7 +3,6 @@ use colored::{ColoredString, Colorize};
 use env_logger::{fmt::Formatter as LogFormatter, Builder as LogBuilder};
 use lazy_static::lazy_static;
 use log::{Level as LogLevel, LevelFilter as LogLevelFilter, Record as LogRecord};
-use serde::Serialize;
 use std::{
     env,
     io::{self, Write},
@@ -74,21 +73,6 @@ pub fn read_token_from_stdin() -> Result<Option<String>> {
     .context("Failed to read API token from stdin.")?;
     input = input.trim().into();
     Ok(if !input.is_empty() { Some(input) } else { None })
-}
-
-pub fn print_resources_as_json<Resource>(
-    resources: impl IntoIterator<Item = Resource>,
-    mut writer: impl Write,
-) -> Result<()>
-where
-    Resource: Serialize,
-{
-    for resource in resources {
-        serde_json::to_writer(&mut writer, &resource)
-            .context("Could not serialise resource.")
-            .and_then(|_| writeln!(writer).context("Failed to write JSON resource to stdout."))?;
-    }
-    Ok(())
 }
 
 lazy_static! {

--- a/cli/tests/test_buckets.rs
+++ b/cli/tests/test_buckets.rs
@@ -16,7 +16,7 @@ fn test_bucket_lifecycle() {
         "--transform-tag",
         "generic_simple.0.QR5PW4VZ",
     ]);
-    assert!(output.is_empty(), "{}", output);
+    assert!(output.contains(&new_bucket_name), "{}", output);
 
     let output = cli.run(&["get", "buckets"]);
     assert!(output.contains(&new_bucket_name), "{}", output);

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -17,7 +17,7 @@ impl TestDataset {
         let sep_index = user.len();
 
         let output = cli.run(&["create", "dataset", &full_name]);
-        assert!(output.is_empty());
+        assert!(output.contains(&full_name));
 
         Self {
             full_name,
@@ -32,7 +32,7 @@ impl TestDataset {
         let sep_index = user.len();
 
         let output = cli.run(["create", "dataset", &full_name].iter().chain(args));
-        assert!(output.is_empty());
+        assert!(output.contains(&full_name));
 
         Self {
             full_name,
@@ -129,7 +129,7 @@ fn test_create_update_dataset_custom() {
     }
 
     let get_dataset_info = || -> DatasetInfo {
-        let output = cli.run(&["get", "datasets", dataset.identifier(), "--output=json"]);
+        let output = cli.run(&["--output=json", "get", "datasets", dataset.identifier()]);
         serde_json::from_str::<Dataset>(&output).unwrap().into()
     };
 
@@ -186,16 +186,16 @@ fn test_create_dataset_with_source() {
     let source = TestSource::new();
     let dataset = TestDataset::new_args(&[&format!("--source={}", source.identifier())]);
 
-    let output = cli.run(&["get", "datasets", "--output=json", dataset.identifier()]);
+    let output = cli.run(&["--output=json", "get", "datasets", dataset.identifier()]);
     let dataset_info: Dataset = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(&dataset_info.owner.0, dataset.owner());
     assert_eq!(&dataset_info.name.0, dataset.name());
     assert_eq!(dataset_info.source_ids.len(), 1);
 
     let source_output = cli.run(&[
+        "--output=json",
         "get",
         "sources",
-        "--output=json",
         &dataset_info.source_ids.first().unwrap().0,
     ]);
     let source_info: Source = serde_json::from_str(source_output.trim()).unwrap();
@@ -221,7 +221,7 @@ fn test_create_dataset_model_family() {
     let cli = TestCli::get();
     let dataset = TestDataset::new_args(&["--model-family==german"]);
 
-    let output = cli.run(&["get", "datasets", "--output=json", dataset.identifier()]);
+    let output = cli.run(&["--output=json", "get", "datasets", dataset.identifier()]);
     let dataset_info: Dataset = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(&dataset_info.owner.0, dataset.owner());
     assert_eq!(&dataset_info.name.0, dataset.name());
@@ -254,7 +254,7 @@ fn test_create_dataset_wrong_model_family() {
 fn test_create_dataset_copy_annotations() {
     let cli = TestCli::get();
     let dataset1 = TestDataset::new();
-    let dataset1_output = cli.run(&["get", "datasets", "--output=json", dataset1.identifier()]);
+    let dataset1_output = cli.run(&["--output=json", "get", "datasets", dataset1.identifier()]);
     let dataset1_info: Dataset = serde_json::from_str(dataset1_output.trim()).unwrap();
 
     let output = cli

--- a/cli/tests/test_sources.rs
+++ b/cli/tests/test_sources.rs
@@ -16,7 +16,7 @@ impl TestSource {
         let sep_index = user.len();
 
         let output = cli.run(&["create", "source", &full_name]);
-        assert!(output.is_empty());
+        assert!(output.contains(&full_name));
 
         Self {
             full_name,
@@ -31,7 +31,7 @@ impl TestSource {
         let sep_index = user.len();
 
         let output = cli.run(["create", "source", &full_name].iter().chain(args));
-        assert!(output.is_empty());
+        assert!(output.contains(&full_name));
 
         Self {
             full_name,
@@ -52,7 +52,7 @@ impl TestSource {
     }
 
     pub fn get(&self) -> Source {
-        let output = TestCli::get().run(&["get", "sources", self.identifier(), "--output=json"]);
+        let output = TestCli::get().run(&["--output=json", "get", "sources", self.identifier()]);
         serde_json::from_str::<Source>(&output).unwrap()
     }
 }
@@ -135,7 +135,7 @@ fn test_create_update_source_custom() {
     }
 
     let get_source_info = || -> SourceInfo {
-        let output = cli.run(&["get", "sources", source.identifier(), "--output=json"]);
+        let output = cli.run(&["--output=json", "get", "sources", source.identifier()]);
         serde_json::from_str::<Source>(&output).unwrap().into()
     };
 


### PR DESCRIPTION
This PR:

- refactors the collection of `print_*_table` functions into a struct, `Printer`, and trait, `DisplayTable`.
  - also extends the `Iterator` trait to allow easy printing of iterables of resources
- adds printing functionality to the resources returned in the `create` and `update` subcommands

This is a breaking change. Users updating to a new version of the cli will need to update their usage. If desired, I could leave the old `-o/--output` flags in, and somehow shim them in (overriding the global output flag preference). This would make it a back-compatible change.

New sample usage:

```bash
$ re -ojson create source org1/tmp | jq
W TLS certificate verification is disabled. Do NOT use this over an insecure network.
I New source `org1/tmp` [id: 7fde97d466fcc74e] created successfully
{
  "id": "7fde97d466fcc74e",
  "owner": "org1",
  "name": "tmp",
  "title": "",
  "description": "",
  "language": "en",
  "should_translate": false,
  "created_at": "2021-07-02T13:43:22.020Z",
  "updated_at": "2021-07-02T13:43:22.020Z"
}
```

Open to bikeshedding on the trait names :fearful: 