### PR TITLE
Deserialize thread properties when using labellings route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Deserialize thread properties when downloading comments for a dataset (the `-d
+  dataset` option for `re get comments`). This limitation exists as only the
+  /labellings API route returns thread properties.
+
 # v0.8.0
 
 ## Breaking

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -339,6 +339,8 @@ pub struct AnnotatedComment {
     pub labelling: Option<Labelling>,
     #[serde(skip_serializing_if = "should_skip_serializing_entities")]
     pub entities: Option<Entities>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_properties: Option<ThreadProperties>,
 }
 
 impl AnnotatedComment {
@@ -375,6 +377,15 @@ impl AnnotatedComment {
         });
         self
     }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ThreadProperties {
+    duration: Option<NotNan<f64>>,
+    response_time: Option<NotNan<f64>>,
+    num_messages: u64,
+    thread_position: u64,
+    first_sender: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/cli/src/commands/get.rs
+++ b/cli/src/commands/get.rs
@@ -197,6 +197,7 @@ pub fn run(get_args: &GetArgs, client: Client, printer: &Printer) -> Result<()> 
                     comment,
                     labelling: None,
                     entities: None,
+                    thread_properties: None,
                 }),
                 &mut writer,
             )?
@@ -417,6 +418,7 @@ fn download_comments(
                         comment,
                         labelling: None,
                         entities: None,
+                        thread_properties: None,
                     }),
                     &mut writer,
                 )


### PR DESCRIPTION
This PR is a hot fix to provide a way to download thread properites. These are now deserialized when dowloading comments for a dataset, `re get comments source -d dataset`. This limitation exists as only the `/labellings` API route returns thread properties.

Note, the thread properties are returned top-level as that's what the API does, e.g. 
```json
{
  "comment": {
    "id": "11047305213",
    "uid": "530f10db824404b5.11047305213",
    "thread_id": "3c3131303437333035323e",
    "timestamp": "2020-01-09T16:34:45Z",
    "messages": [],
    "user_properties": {}
  },
  "thread_properties": {
    "duration": 0,
    "response_time": 0,
    "num_messages": 19,
    "thread_position": 5,
    "first_sender": "cs@farfetch.com"
  }
}
```
