### PR TITLE
config: add get-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Deserialize thread properties when downloading comments for a dataset (the `-d
   dataset` option for `re get comments`). This limitation exists as only the
   /labellings API route returns thread properties.
+- Added `re config get-token [context]` which dumps the auth token for the
+  current or a different, given context.
 
 # v0.8.0
 


### PR DESCRIPTION
Simple addition that prints the token for a given context e.g.

```
$ re config get-token local
BXNAJGQQ75V3NPFYPRKE4YKUOKOYQATZWC23YDPS27K4TP7Y
```

```
$ re config get-token some-context
E No such context `some-context`.
```

This can be used in a curl command like

```
curl -XPOST                                                           \
    -H"Content-type:application/json"                                 \
    -H"Authorization: Bearer $(re config get-token beazley)"          \
    https://beazley.reinfer.io/api/_private/users/support-tenants/add \
    -d '{"email": "joe.prosser@reinfer.io"}'
```
