### PR TITLE
cli: add create annotations command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Added
+
+- New `re create annotations` command for uploading annotations (labels and
+  entities) to existing comments in a dataset, without having to use `re create comments`.
+  This avoids potentially - and unknowingly - modifying the underlying comments in the source.
+
 # v.0.9.0
 
 ## Breaking

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -64,10 +64,11 @@ pub use crate::{
             Identifier as BucketIdentifier, Name as BucketName, NewBucket, TransformTag,
         },
         comment::{
-            AnnotatedComment, Comment, CommentFilter, CommentsIterPage, Continuation, Entity,
-            Id as CommentId, Label, Message, MessageBody, MessageSignature, MessageSubject,
-            NewAnnotatedComment, NewComment, NewEntities, NewLabelling, PropertyMap, PropertyValue,
-            Sentiment, SyncCommentsResponse, Uid as CommentUid,
+            AnnotatedComment, Comment, CommentFilter, CommentsIterPage, Continuation,
+            EitherLabelling, Entity, HasAnnotations, Id as CommentId, Label, Message, MessageBody,
+            MessageSignature, MessageSubject, NewAnnotatedComment, NewComment, NewEntities,
+            NewLabelling, PropertyMap, PropertyValue, Sentiment, SyncCommentsResponse,
+            Uid as CommentUid,
         },
         dataset::{
             Dataset, FullName as DatasetFullName, Id as DatasetId, Identifier as DatasetIdentifier,

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 
 use crate::{
     error::{Error, Result},
@@ -11,6 +10,10 @@ use crate::{
         source::Id as SourceId,
         user::Username,
     },
+};
+use std::{
+    fmt::{Display, Formatter, Result as FmtResult},
+    str::FromStr,
 };
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -93,6 +96,19 @@ impl FromStr for Identifier {
         } else {
             FullName::from_str(string).map(Identifier::FullName)
         }
+    }
+}
+
+impl Display for Identifier {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+        write!(
+            formatter,
+            "{}",
+            match self {
+                Identifier::Id(id) => &id.0,
+                Identifier::FullName(full_name) => &full_name.0,
+            }
+        )
     }
 }
 

--- a/cli/src/commands/create/annotations.rs
+++ b/cli/src/commands/create/annotations.rs
@@ -1,0 +1,252 @@
+use crate::progress::{Options as ProgressOptions, Progress};
+use anyhow::{Context, Result};
+use colored::Colorize;
+use log::info;
+use reinfer_client::{
+    resources::comment::{EitherLabelling, HasAnnotations},
+    Client, CommentId, CommentUid, DatasetFullName, DatasetIdentifier, NewEntities, NewLabelling,
+    Source, SourceIdentifier,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader},
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct CreateAnnotationsArgs {
+    #[structopt(short = "f", long = "file", parse(from_os_str))]
+    /// Path to JSON file with annotations. If not specified, stdin will be used.
+    annotations_path: Option<PathBuf>,
+
+    #[structopt(short = "s", long = "source")]
+    /// Name or id of the source containing the annotated comments
+    source: SourceIdentifier,
+
+    #[structopt(short = "d", long = "dataset")]
+    /// Dataset (name or id) where to push the annotations. The dataset must contain the source.
+    dataset: DatasetIdentifier,
+
+    #[structopt(long)]
+    /// Don't display a progress bar (only applicable when --file is used).
+    no_progress: bool,
+}
+
+pub fn create(client: &Client, args: &CreateAnnotationsArgs) -> Result<()> {
+    let source = client
+        .get_source(args.source.clone())
+        .with_context(|| format!("Unable to get source {}", args.source))?;
+    let source_name = source.full_name();
+
+    let dataset = client
+        .get_dataset(args.dataset.clone())
+        .with_context(|| format!("Unable to get dataset {}", args.dataset))?;
+    let dataset_name = dataset.full_name();
+
+    let statistics = match &args.annotations_path {
+        Some(annotations_path) => {
+            info!(
+                "Uploading comments from file `{}` to source `{}` [id: {}] and dataset `{}` [id: {}]",
+                annotations_path.display(),
+                source_name.0,
+                source.id.0,
+                dataset_name.0,
+                dataset.id.0,
+            );
+            let file = BufReader::new(File::open(annotations_path).with_context(|| {
+                format!("Could not open file `{}`", annotations_path.display())
+            })?);
+            let file_metadata = file.get_ref().metadata().with_context(|| {
+                format!(
+                    "Could not get file metadata for `{}`",
+                    annotations_path.display()
+                )
+            })?;
+
+            let statistics = Arc::new(Statistics::new());
+            let progress = if args.no_progress {
+                None
+            } else {
+                Some(progress_bar(file_metadata.len(), &statistics))
+            };
+            upload_annotations_from_reader(client, &source, file, &statistics, &dataset_name)?;
+            if let Some(mut progress) = progress {
+                progress.done();
+            }
+            Arc::try_unwrap(statistics)
+                .expect("Not all references to `statistics` have been disposed of")
+        }
+        None => {
+            info!(
+                "Uploading annotations from stdin to source `{}` [id: {}] and dataset `{} [id: {}]",
+                source_name.0, source.id.0, dataset_name.0, dataset.id.0
+            );
+            let statistics = Statistics::new();
+            upload_annotations_from_reader(
+                client,
+                &source,
+                BufReader::new(io::stdin()),
+                &statistics,
+                &dataset_name,
+            )?;
+            statistics
+        }
+    };
+
+    info!(
+        "Successfully uploaded {} annotations.",
+        statistics.num_annotations(),
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn upload_annotations_from_reader(
+    client: &Client,
+    source: &Source,
+    annotations: impl BufRead,
+    statistics: &Statistics,
+    dataset_name: &DatasetFullName,
+) -> Result<()> {
+    for read_comment_result in read_annotations_iter(annotations, Some(statistics)) {
+        let new_comment = read_comment_result?;
+        if new_comment.has_annotations() {
+            client
+                .update_labelling(
+                    dataset_name,
+                    &CommentUid(format!("{}.{}", source.id.0, new_comment.comment.id.0)),
+                    new_comment
+                        .labelling
+                        .map(Into::<Vec<NewLabelling>>::into)
+                        .as_deref(),
+                    new_comment.entities.as_ref(),
+                )
+                .context("Could not update labelling for comment")?;
+            statistics.add_annotation();
+        }
+    }
+
+    Ok(())
+}
+
+/// This struct only contains the minimal amount of data required to be able to upload annotations
+/// via the api, while still matching the structure of the NewComment struct.  This makes the jsonl
+/// files downloaded via `re` compatible with the `re create annotations` command.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+struct CommentIdComment {
+    id: CommentId,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+struct NewAnnotation {
+    pub comment: CommentIdComment,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labelling: Option<EitherLabelling>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entities: Option<NewEntities>,
+}
+
+impl HasAnnotations for NewAnnotation {
+    fn has_annotations(&self) -> bool {
+        self.labelling.has_annotations() || self.entities.has_annotations()
+    }
+}
+
+fn read_annotations_iter<'a>(
+    mut annotations: impl BufRead + 'a,
+    statistics: Option<&'a Statistics>,
+) -> impl Iterator<Item = Result<NewAnnotation>> + 'a {
+    let mut line = String::new();
+    let mut line_number: u32 = 0;
+    std::iter::from_fn(move || {
+        line_number += 1;
+        line.clear();
+
+        let read_result = annotations
+            .read_line(&mut line)
+            .with_context(|| format!("Could not read line {} from input stream", line_number));
+
+        match read_result {
+            Ok(0) => return None,
+            Ok(bytes_read) => {
+                if let Some(s) = statistics {
+                    s.add_bytes_read(bytes_read)
+                }
+            }
+            Err(e) => return Some(Err(e)),
+        }
+
+        Some(
+            serde_json::from_str::<NewAnnotation>(line.trim_end()).with_context(|| {
+                format!(
+                    "Could not parse annotations at line {} from input stream",
+                    line_number,
+                )
+            }),
+        )
+    })
+}
+
+#[derive(Debug)]
+pub struct StatisticsUpdate {
+    uploaded: usize,
+}
+
+#[derive(Debug)]
+pub struct Statistics {
+    bytes_read: AtomicUsize,
+    annotations: AtomicUsize,
+}
+
+impl Statistics {
+    fn new() -> Self {
+        Self {
+            bytes_read: AtomicUsize::new(0),
+            annotations: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline]
+    fn add_bytes_read(&self, bytes_read: usize) {
+        self.bytes_read.fetch_add(bytes_read, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_annotation(&self) {
+        self.annotations.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn bytes_read(&self) -> usize {
+        self.bytes_read.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    pub fn num_annotations(&self) -> usize {
+        self.annotations.load(Ordering::SeqCst)
+    }
+}
+
+fn basic_statistics(statistics: &Statistics) -> (u64, String) {
+    let bytes_read = statistics.bytes_read();
+    let num_annotations = statistics.num_annotations();
+    (
+        bytes_read as u64,
+        format!("{} {}", num_annotations, "annotations".dimmed(),),
+    )
+}
+
+fn progress_bar(total_bytes: u64, statistics: &Arc<Statistics>) -> Progress {
+    Progress::new(
+        basic_statistics,
+        statistics,
+        Some(total_bytes),
+        ProgressOptions { bytes_units: true },
+    )
+}

--- a/cli/src/commands/create/mod.rs
+++ b/cli/src/commands/create/mod.rs
@@ -1,3 +1,4 @@
+mod annotations;
 mod bucket;
 mod comments;
 mod dataset;
@@ -7,9 +8,9 @@ mod source;
 mod user;
 
 use self::{
-    bucket::CreateBucketArgs, comments::CreateCommentsArgs, dataset::CreateDatasetArgs,
-    emails::CreateEmailsArgs, project::CreateProjectArgs, source::CreateSourceArgs,
-    user::CreateUserArgs,
+    annotations::CreateAnnotationsArgs, bucket::CreateBucketArgs, comments::CreateCommentsArgs,
+    dataset::CreateDatasetArgs, emails::CreateEmailsArgs, project::CreateProjectArgs,
+    source::CreateSourceArgs, user::CreateUserArgs,
 };
 use crate::printer::Printer;
 use anyhow::Result;
@@ -38,6 +39,10 @@ pub enum CreateArgs {
     /// Create or update comments
     Comments(CreateCommentsArgs),
 
+    #[structopt(name = "annotations")]
+    /// Create or update annotations
+    Annotations(CreateAnnotationsArgs),
+
     #[structopt(name = "emails")]
     /// Create or update emails
     Emails(CreateEmailsArgs),
@@ -54,6 +59,7 @@ pub fn run(create_args: &CreateArgs, client: Client, printer: &Printer) -> Resul
         CreateArgs::Dataset(dataset_args) => dataset::create(&client, dataset_args, printer),
         CreateArgs::Project(project_args) => project::create(&client, project_args, printer),
         CreateArgs::Comments(comments_args) => comments::create(&client, comments_args),
+        CreateArgs::Annotations(annotations_args) => annotations::create(&client, annotations_args),
         CreateArgs::Emails(emails_args) => emails::create(&client, emails_args),
         CreateArgs::User(user_args) => user::create(&client, user_args, printer),
     }

--- a/cli/src/commands/get.rs
+++ b/cli/src/commands/get.rs
@@ -8,7 +8,7 @@ use colored::Colorize;
 use log::info;
 use reinfer_client::{
     AnnotatedComment, BucketIdentifier, Client, CommentId, CommentsIterTimerange, DatasetFullName,
-    DatasetIdentifier, ProjectName, Source, SourceIdentifier, TriggerFullName,
+    DatasetIdentifier, HasAnnotations, ProjectName, Source, SourceIdentifier, TriggerFullName,
 };
 use std::{
     fs::File,


### PR DESCRIPTION
This PR adds support for the `re create annotations` command.

```
Create or update annotations

USAGE:
    re create annotations [FLAGS] [OPTIONS] --dataset <dataset> --source <source>

FLAGS:
    -h, --help           Prints help information
        --no-progress    Don't display a progress bar (only applicable when --file is used)
    -V, --version        Prints version information

OPTIONS:
    -f, --file <annotations-path>    Path to JSON file with annotations. If not specified, stdin will be used
    -d, --dataset <dataset>          Dataset (name or id) where to push the annotations. The dataset must contain the
                                     source
    -s, --source <source>            Name or id of the source containing the annotated comments
```

The input format is similar to the one expected in `re create comments`, so that users can download comments from a dataset and re-use that same `jsonl` file to upload annotations to a new dataset.
However, strictly speaking, the expected structure is a `jsonl` file containing lines of json:
```
{
    "comment": {
        "id": "<comment_id>"
    },
    "labelling": [<labels (legacy format accepted)>],
    "entities": [<entities>]
}
```
where `"labelling"` and `"entities"` are only expected if there are labels or entities but are not required.