### PR TITLE
projects: support --force project deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New `re create annotations` command for uploading annotations (labels and
   entities) to existing comments in a dataset, without having to use `re create comments`.
   This avoids potentially - and unknowingly - modifying the underlying comments in the source.
+- Add support to `--force` delete projects with existing resources.
 
 # v.0.9.0
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -11,6 +11,7 @@ use reqwest::{
     header::{self, HeaderMap, HeaderValue},
     IntoUrl, Proxy, Result as ReqwestResult,
 };
+use resources::project::ForceDeleteProject;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{cell::Cell, fmt::Display, path::Path};
@@ -667,8 +668,18 @@ impl Client {
     }
 
     /// Deletes an existing project.
-    pub fn delete_project(&self, project_name: &ProjectName) -> Result<()> {
-        self.delete(self.endpoints.project_by_name(project_name)?)?;
+    pub fn delete_project(
+        &self,
+        project_name: &ProjectName,
+        force_delete: ForceDeleteProject,
+    ) -> Result<()> {
+        let endpoint = self.endpoints.project_by_name(project_name)?;
+        match force_delete {
+            ForceDeleteProject::No => self.delete(endpoint)?,
+            ForceDeleteProject::Yes => {
+                self.delete_query(endpoint, Some(&json!({ "force": true })))?
+            }
+        };
         Ok(())
     }
 

--- a/api/src/resources/project.rs
+++ b/api/src/resources/project.rs
@@ -72,3 +72,9 @@ pub struct UpdateProjectRequest<'request> {
 pub(crate) struct UpdateProjectResponse {
     pub project: Project,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForceDeleteProject {
+    No,
+    Yes,
+}

--- a/cli/src/commands/delete.rs
+++ b/cli/src/commands/delete.rs
@@ -8,8 +8,8 @@ use std::sync::{
 use structopt::StructOpt;
 
 use reinfer_client::{
-    BucketIdentifier, Client, CommentId, CommentsIter, CommentsIterTimerange, DatasetIdentifier,
-    ProjectName, Source, SourceIdentifier,
+    resources::project::ForceDeleteProject, BucketIdentifier, Client, CommentId, CommentsIter,
+    CommentsIterTimerange, DatasetIdentifier, ProjectName, Source, SourceIdentifier,
 };
 
 use crate::progress::{Options as ProgressOptions, Progress};
@@ -87,6 +87,10 @@ pub enum DeleteArgs {
         #[structopt(name = "project")]
         /// Name or id of the project to delete
         project: ProjectName,
+
+        #[structopt(long)]
+        /// Force deletion of the project, even if it's not empty.
+        force: bool,
     },
 }
 
@@ -137,9 +141,14 @@ pub fn run(delete_args: &DeleteArgs, client: Client) -> Result<()> {
                 .context("Operation to delete bucket has failed.")?;
             log::info!("Deleted bucket.");
         }
-        DeleteArgs::Project { project } => {
+        DeleteArgs::Project { project, force } => {
+            let force_delete = if *force {
+                ForceDeleteProject::Yes
+            } else {
+                ForceDeleteProject::No
+            };
             client
-                .delete_project(project)
+                .delete_project(project, force_delete)
                 .context("Operation to delete project has failed.")?;
             log::info!("Deleted project.");
         }

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -66,14 +66,17 @@ impl TestCli {
         command
     }
 
+    #[track_caller]
     pub fn run(&self, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> String {
         self.output(self.command().args(args))
     }
 
+    #[track_caller]
     pub fn run_and_error(&self, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> String {
         self.output_error(self.command().args(args))
     }
 
+    #[track_caller]
     pub fn run_with_stdin(
         &self,
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
@@ -100,6 +103,7 @@ impl TestCli {
         String::from_utf8(output.stdout).unwrap()
     }
 
+    #[track_caller]
     pub fn output(&self, command: &mut Command) -> String {
         let output = command.output().unwrap();
 
@@ -113,6 +117,7 @@ impl TestCli {
         String::from_utf8(output.stdout).unwrap()
     }
 
+    #[track_caller]
     pub fn output_error(&self, command: &mut Command) -> String {
         let output = command.output().unwrap();
 


### PR DESCRIPTION
Adds a `re delete project --force` option to use cascade deletion as recently added to the webapp. 