### PR TITLE
api: make thread position optional

### DIFF
--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -419,7 +419,7 @@ pub struct ThreadProperties {
     duration: Option<NotNan<f64>>,
     response_time: Option<NotNan<f64>>,
     num_messages: u64,
-    thread_position: u64,
+    thread_position: Option<u64>,
     first_sender: Option<String>,
 }
 


### PR DESCRIPTION
When uploading annotated comments `thread_position` is not guaranteed to be returned by the API. This PR ensures that uploads do not fail when those `thread_position` is not present in the response. 