### PR TITLE
comments: Return id for failed comment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   entities) to existing comments in a dataset, without having to use `re create comments`.
   This avoids potentially - and unknowingly - modifying the underlying comments in the source.
 - Add support to `--force` delete projects with existing resources.
+- Print comment `uid` when a comment upload fails due to bad annotations.
 
 # v.0.9.0
 

--- a/cli/src/commands/create/comments.rs
+++ b/cli/src/commands/create/comments.rs
@@ -280,7 +280,9 @@ fn upload_batch(
                     labelling.as_deref(),
                     entities.as_ref(),
                 )
-                .context("Could not update labelling for comment")?;
+                .with_context(|| {
+                    format!("Could not update labelling for comment `{}`", comment_uid.0,)
+                })?;
             statistics.add_annotation();
         }
     }


### PR DESCRIPTION
Adds a `uid` to the error message when uploading annotations - I found this much more useful when debugging failing annotation uploads.