### PR TITLE
api/cli: default `has-sentiment` to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Breaking
+
+- `re create dataset` will default to sentiment disabled if `--has-sentiment` is not provided.
+
 # v0.10.2
 
 ## Bug Fixes

--- a/cli/src/commands/create/dataset.rs
+++ b/cli/src/commands/create/dataset.rs
@@ -22,7 +22,10 @@ pub struct CreateDatasetArgs {
     /// Set the description of the new dataset
     description: Option<String>,
 
-    #[structopt(long = "has-sentiment")]
+    #[structopt(
+        long = "has-sentiment",
+        help = "Enable sentiment prediction for the dataset [default: false]"
+    )]
     /// Enable sentiment prediction for the dataset
     has_sentiment: Option<bool>,
 
@@ -95,7 +98,7 @@ pub fn create(client: &Client, args: &CreateDatasetArgs, printer: &Printer) -> R
                 source_ids: &source_ids,
                 title: title.as_deref(),
                 description: description.as_deref(),
-                has_sentiment: *has_sentiment,
+                has_sentiment: Some(has_sentiment.unwrap_or(false)),
                 entity_defs: if entity_defs.is_empty() {
                     None
                 } else {


### PR DESCRIPTION
Don't know if this is controversial, but I think if we make `--has-sentiment` optional then it should default to `false`, since that's what we want most of the time. (I think that it defaults to `true` in api v1 for purely historical reasons). Motivated by accidentally creating sentiment-enabled datasets at UBS multiple times, which was an ordeal to change.

I have no idea what I'm doing here but it seems to work!