### PR TITLE
ci: only upload binary when it does not already exist

### DIFF
--- a/cli/publish-binaries
+++ b/cli/publish-binaries
@@ -14,9 +14,18 @@ build_and_upload() {
   echo "Building version $CLI_VERSION ($target: $artefact)"
 
   cargo build --release --target "$target"
-  # Upload executable
-  gsutil cp "../target/${target}/release/$artefact" "gs://reinfer-public/cli/bin/${target}/${CLI_VERSION}/$artefact"
-  gsutil cp "../target/${target}/release/$artefact" "gs://reinfer-public/cli/bin/${target}/latest/$artefact"
+
+  # Upload executables if they do not already exist
+  export VERSIONED_GS_PATH="gs://reinfer-public/cli/bin/${target}/${CLI_VERSION}/$artefact"
+  export LATEST_GS_PATH="gs://reinfer-public/cli/bin/${target}/latest/$artefact"
+
+  if ! gsutil -q stat "$VERSIONED_GS_PATH"; then
+    gsutil cp "../target/${target}/release/$artefact" "$VERSIONED_GS_PATH"
+  fi
+
+  if ! gsutil -q stat "$LATEST_GS_PATH"; then
+    gsutil cp "../target/${target}/release/$artefact" "$LATEST_GS_PATH"
+  fi
 }
 
 case $BUILD_PLATFORM in


### PR DESCRIPTION
Only upload a binary if it does not already exist - previously this would cause failures when retrying a previous attempt that had failed to publish all required binaries