### PR TITLE
api/cli: fix deserialization of statistics response

### DIFF
--- a/api/src/resources/statistics.rs
+++ b/api/src/resources/statistics.rs
@@ -1,3 +1,4 @@
+use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -7,5 +8,5 @@ pub(crate) struct GetResponse {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Statistics {
-    pub num_comments: usize,
+    pub num_comments: NotNan<f64>,
 }

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, StructOpt)]
 pub enum ConfigArgs {
     #[structopt(name = "add")]

--- a/cli/src/commands/create/annotations.rs
+++ b/cli/src/commands/create/annotations.rs
@@ -200,11 +200,6 @@ fn read_annotations_iter<'a>(
 }
 
 #[derive(Debug)]
-pub struct StatisticsUpdate {
-    uploaded: usize,
-}
-
-#[derive(Debug)]
 pub struct Statistics {
     bytes_read: AtomicUsize,
     annotations: AtomicUsize,

--- a/cli/src/commands/get.rs
+++ b/cli/src/commands/get.rs
@@ -382,7 +382,7 @@ fn download_comments(
     let make_progress = |dataset_name: Option<&DatasetFullName>| -> Result<Progress> {
         Ok(get_comments_progress_bar(
             if let Some(dataset_name) = dataset_name {
-                client
+                *client
                     .get_statistics(dataset_name)
                     .context("Operation to get comment count has failed..")?
                     .num_comments as u64


### PR DESCRIPTION
We recently changed the api to return floats instead of integers in the `statistics` endpoint, which broke the deserialization logic here.