### PR TITLE
resources: statistics should expect f64 not usize

### DIFF
--- a/api/src/resources/statistics.rs
+++ b/api/src/resources/statistics.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub(crate) struct GetResponse {
     pub statistics: Statistics,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Statistics {
-    pub num_comments: usize,
+    pub num_comments: f64,
 }


### PR DESCRIPTION
Fixes a bug where `get comments` would return an error due to statistics expecting a `usize` instead of `f64`