### PR TITLE
api/cli: rename organisation -> project

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Run tests
         run: ./scripts/check
         env:
-          REINFER_CLI_TEST_ORG: ${{ secrets.REINFER_CLI_TEST_ORG }}
+          REINFER_CLI_TEST_PROJECT: ${{ secrets.REINFER_CLI_TEST_PROJECT }}
           REINFER_CLI_TEST_TOKEN: ${{ secrets.REINFER_CLI_TEST_TOKEN }}
           REINFER_CLI_TEST_ENDPOINT: ${{ secrets.REINFER_CLI_TEST_ENDPOINT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Breaking
 
 - `re create dataset` will default to sentiment disabled if `--has-sentiment` is not provided.
+ - Renames organisation -> project throughout, including in the CLI command line
+   arguments for consistency with the new API
 
 # v0.10.2
 

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -28,8 +28,11 @@ pub enum Error {
     #[error("Expected a username or user id, got: {}", identifier)]
     BadUserIdentifier { identifier: String },
 
-    #[error("Unknown organisation permission: {}", permission)]
-    BadOrganisationPermission { permission: String },
+    #[error("Expected a valid project name, got: {}", identifier)]
+    BadProjectIdentifier { identifier: String },
+
+    #[error("Unknown project permission: {}", permission)]
+    BadProjectPermission { permission: String },
 
     #[error("Unknown global permission: {}", permission)]
     BadGlobalPermission { permission: String },

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -96,7 +96,7 @@ pub use crate::{
         },
         user::{
             Email, GlobalPermission, Id as UserId, Identifier as UserIdentifier,
-            ModifiedPermissions, NewUser, Organisation, OrganisationPermission, User, Username,
+            ModifiedPermissions, NewUser, ProjectPermission, User, Username,
         },
     },
 };

--- a/api/src/resources/project.rs
+++ b/api/src/resources/project.rs
@@ -2,16 +2,28 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-use crate::resources::user::Id as UserId;
+use crate::{
+    error::{Error, Result},
+    resources::user::Id as UserId,
+};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct ProjectName(pub String);
 
 impl FromStr for ProjectName {
-    type Err = std::convert::Infallible;
+    type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(s.to_owned()))
+    fn from_str(string: &str) -> Result<Self> {
+        if string
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            Ok(Self(string.into()))
+        } else {
+            Err(Error::BadProjectIdentifier {
+                identifier: string.into(),
+            })
+        }
     }
 }
 

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -8,9 +8,9 @@ use std::{
     process::{Command, Stdio},
 };
 
-static REINFER_CLI_TEST_ORG: Lazy<String> = Lazy::new(|| {
-    env::var("REINFER_CLI_TEST_ORG")
-        .expect("REINFER_CLI_TEST_ORG must be set for integration tests")
+static REINFER_CLI_TEST_PROJECT: Lazy<String> = Lazy::new(|| {
+    env::var("REINFER_CLI_TEST_PROJECT")
+        .expect("REINFER_CLI_TEST_PROJECT must be set for integration tests")
 });
 static REINFER_CLI_TEST_ENDPOINT: Lazy<Option<String>> =
     Lazy::new(|| env::var("REINFER_CLI_TEST_ENDPOINT").ok());
@@ -42,8 +42,8 @@ impl TestCli {
         serde_json::from_str::<User>(&output).expect("Failed to deserialize user response")
     }
 
-    pub fn organisation() -> String {
-        REINFER_CLI_TEST_ORG.to_owned()
+    pub fn project() -> String {
+        REINFER_CLI_TEST_PROJECT.to_owned()
     }
 
     pub fn command(&self) -> Command {

--- a/cli/tests/test_buckets.rs
+++ b/cli/tests/test_buckets.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 #[test]
 fn test_bucket_lifecycle() {
     let cli = TestCli::get();
-    let owner = TestCli::organisation();
+    let owner = TestCli::project();
 
     let new_bucket_name = format!("{}/test-source-{}", owner, Uuid::new_v4());
 
@@ -32,7 +32,7 @@ fn test_bucket_lifecycle() {
 #[test]
 fn test_bucket_with_invalid_transform_tag_fails() {
     let cli = TestCli::get();
-    let owner = TestCli::organisation();
+    let owner = TestCli::project();
 
     let new_bucket_name = format!("{}/test-source-{}", owner, Uuid::new_v4());
 

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -16,7 +16,7 @@ pub struct TestDataset {
 impl TestDataset {
     pub fn new() -> Self {
         let cli = TestCli::get();
-        let user = TestCli::organisation();
+        let user = TestCli::project();
         let full_name = format!("{}/test-dataset-{}", user, Uuid::new_v4());
         let sep_index = user.len();
 
@@ -31,7 +31,7 @@ impl TestDataset {
 
     pub fn new_args(args: &[&str]) -> Self {
         let cli = TestCli::get();
-        let user = TestCli::organisation();
+        let user = TestCli::project();
         let full_name = format!("{}/test-dataset-{}", user, Uuid::new_v4());
         let sep_index = user.len();
 
@@ -352,11 +352,7 @@ fn test_create_dataset_wrong_model_family() {
             "create",
             "dataset",
             "--model-family==non-existent-family",
-            &format!(
-                "{}/test-dataset-{}",
-                TestCli::organisation(),
-                Uuid::new_v4()
-            ),
+            &format!("{}/test-dataset-{}", TestCli::project(), Uuid::new_v4()),
         ])
         .output()
         .unwrap();
@@ -378,11 +374,7 @@ fn test_create_dataset_copy_annotations() {
             "create",
             "dataset",
             &format!("--copy-annotations-from={}", dataset1_info.id.0),
-            &format!(
-                "{}/test-dataset-{}",
-                TestCli::organisation(),
-                Uuid::new_v4()
-            ),
+            &format!("{}/test-dataset-{}", TestCli::project(), Uuid::new_v4()),
         ])
         .output()
         .unwrap();

--- a/cli/tests/test_sources.rs
+++ b/cli/tests/test_sources.rs
@@ -11,9 +11,9 @@ pub struct TestSource {
 impl TestSource {
     pub fn new() -> Self {
         let cli = TestCli::get();
-        let user = TestCli::organisation();
-        let full_name = format!("{}/test-source-{}", user, Uuid::new_v4());
-        let sep_index = user.len();
+        let project_name = TestCli::project();
+        let full_name = format!("{}/test-source-{}", project_name, Uuid::new_v4());
+        let sep_index = project_name.len();
 
         let output = cli.run(&["create", "source", &full_name]);
         assert!(output.contains(&full_name));
@@ -26,9 +26,9 @@ impl TestSource {
 
     pub fn new_args(args: &[&str]) -> Self {
         let cli = TestCli::get();
-        let user = TestCli::organisation();
-        let full_name = format!("{}/test-source-{}", user, Uuid::new_v4());
-        let sep_index = user.len();
+        let project_name = TestCli::project();
+        let full_name = format!("{}/test-source-{}", project_name, Uuid::new_v4());
+        let sep_index = project_name.len();
 
         let output = cli.run(["create", "source", &full_name].iter().chain(args));
         assert!(output.contains(&full_name));


### PR DESCRIPTION
Not much to say -- this PR renames organisation -> project throughout the `cli` and `api` crates for consistency with new API