### PR TITLE
api/cli: rename source type to kind

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -87,7 +87,7 @@ pub use crate::{
         project::{NewProject, Project, ProjectName, UpdateProject},
         source::{
             FullName as SourceFullName, Id as SourceId, Identifier as SourceIdentifier,
-            Name as SourceName, NewSource, Source, SourceType, UpdateSource,
+            Name as SourceName, NewSource, Source, SourceKind, UpdateSource,
         },
         statistics::Statistics,
         trigger::{

--- a/api/src/resources/source.rs
+++ b/api/src/resources/source.rs
@@ -24,8 +24,8 @@ pub struct Source {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 
-    #[serde(rename = "_type")]
-    pub source_type: SourceType,
+    #[serde(rename = "_kind")]
+    pub kind: SourceKind,
 }
 
 impl Source {
@@ -109,33 +109,33 @@ impl Display for Identifier {
 }
 
 #[derive(Debug, Clone, SerializeDisplay, DeserializeFromStr, PartialEq, Eq, Hash)]
-pub enum SourceType {
+pub enum SourceKind {
     Call,
     Chat,
     Unknown(Box<str>),
 }
 
-impl FromStr for SourceType {
+impl FromStr for SourceKind {
     type Err = Error;
 
     fn from_str(string: &str) -> Result<Self> {
         Ok(match string {
-            "call" => SourceType::Call,
-            "chat" => SourceType::Chat,
-            value => SourceType::Unknown(value.into()),
+            "call" => SourceKind::Call,
+            "chat" => SourceKind::Chat,
+            value => SourceKind::Unknown(value.into()),
         })
     }
 }
 
-impl Display for SourceType {
+impl Display for SourceKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",
             match self {
-                SourceType::Call => "call",
-                SourceType::Chat => "chat",
-                SourceType::Unknown(value) => value.as_ref(),
+                SourceKind::Call => "call",
+                SourceKind::Chat => "chat",
+                SourceKind::Unknown(value) => value.as_ref(),
             }
         )
     }
@@ -161,8 +161,8 @@ pub struct NewSource<'request> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sensitive_properties: Option<Vec<&'request str>>,
 
-    #[serde(skip_serializing_if = "Option::is_none", rename = "_type")]
-    pub source_type: Option<&'request SourceType>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "_kind")]
+    pub kind: Option<&'request SourceKind>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Default)]
@@ -218,31 +218,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn source_type_roundtrips() {
-        assert_eq!(SourceType::Call, SourceType::from_str("call").unwrap());
+    fn source_kind_roundtrips() {
+        assert_eq!(SourceKind::Call, SourceKind::from_str("call").unwrap());
         assert_eq!(
-            &serde_json::ser::to_string(&SourceType::Call).unwrap(),
+            &serde_json::ser::to_string(&SourceKind::Call).unwrap(),
             "\"call\""
         );
 
-        assert_eq!(SourceType::Chat, SourceType::from_str("chat").unwrap());
+        assert_eq!(SourceKind::Chat, SourceKind::from_str("chat").unwrap());
         assert_eq!(
-            &serde_json::ser::to_string(&SourceType::Chat).unwrap(),
+            &serde_json::ser::to_string(&SourceKind::Chat).unwrap(),
             "\"chat\""
         );
     }
 
     #[test]
-    fn unknown_source_type_roundtrips() {
-        let source_type = SourceType::from_str("unknown").unwrap();
-        match &source_type {
-            SourceType::Unknown(error) => assert_eq!(&**error, "unknown"),
+    fn unknown_source_kind_roundtrips() {
+        let kind = SourceKind::from_str("unknown").unwrap();
+        match &kind {
+            SourceKind::Unknown(error) => assert_eq!(&**error, "unknown"),
             _ => panic!("Expected error to be parsed as Unknown(..)"),
         }
 
-        assert_eq!(
-            &serde_json::ser::to_string(&source_type).unwrap(),
-            "\"unknown\""
-        )
+        assert_eq!(&serde_json::ser::to_string(&kind).unwrap(), "\"unknown\"")
     }
 }

--- a/cli/src/commands/create/source.rs
+++ b/cli/src/commands/create/source.rs
@@ -1,7 +1,7 @@
 use crate::printer::Printer;
 use anyhow::{Context, Result};
 use log::info;
-use reinfer_client::{BucketIdentifier, Client, NewSource, SourceFullName, SourceType};
+use reinfer_client::{BucketIdentifier, Client, NewSource, SourceFullName, SourceKind};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -30,9 +30,9 @@ pub struct CreateSourceArgs {
     /// Bucket to pull emails from.
     bucket: Option<BucketIdentifier>,
 
-    #[structopt(long = "source-type")]
-    /// Set the source type of the new source
-    source_type: Option<SourceType>,
+    #[structopt(long = "kind")]
+    /// Set the kind of the new source
+    kind: Option<SourceKind>,
 }
 
 pub fn create(client: &Client, args: &CreateSourceArgs, printer: &Printer) -> Result<()> {
@@ -43,7 +43,7 @@ pub fn create(client: &Client, args: &CreateSourceArgs, printer: &Printer) -> Re
         language,
         should_translate,
         bucket,
-        source_type,
+        kind,
     } = args;
 
     let bucket_id = match bucket.to_owned() {
@@ -67,7 +67,7 @@ pub fn create(client: &Client, args: &CreateSourceArgs, printer: &Printer) -> Re
                 should_translate: *should_translate,
                 bucket_id,
                 sensitive_properties: None,
-                source_type: source_type.as_ref(),
+                kind: kind.as_ref(),
             },
         )
         .context("Operation to create a source has failed")?;

--- a/cli/src/commands/delete.rs
+++ b/cli/src/commands/delete.rs
@@ -287,10 +287,11 @@ fn delete_comments_progress_bar(statistics: &Arc<Statistics>) -> Progress {
             (
                 num_deleted + num_skipped,
                 format!(
-                    "{} {}{}",
+                    "{} {} [{} {}] total",
                     num_deleted.to_string().bold(),
                     "deleted".dimmed(),
-                    format!(" [{} {}] total", num_skipped, "skipped".dimmed())
+                    num_skipped,
+                    "skipped".dimmed()
                 ),
             )
         },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -150,7 +150,7 @@ fn main() {
 
     if let Err(error) = run(args) {
         error!("An error occurred:");
-        for cause in error.chain().into_iter() {
+        for cause in error.chain() {
             error!(" |- {}", cause);
         }
 

--- a/cli/tests/test_sources.rs
+++ b/cli/tests/test_sources.rs
@@ -119,7 +119,7 @@ fn test_create_update_source_custom() {
         description: String,
         language: String,
         should_translate: bool,
-        source_type: String,
+        kind: String,
     }
 
     impl From<Source> for SourceInfo {
@@ -131,7 +131,7 @@ fn test_create_update_source_custom() {
                 description: source.description,
                 language: source.language,
                 should_translate: source.should_translate,
-                source_type: source.source_type.to_string(),
+                kind: source.kind.to_string(),
             }
         }
     }
@@ -148,7 +148,7 @@ fn test_create_update_source_custom() {
         description: "some description".to_owned(),
         language: "de".to_owned(),
         should_translate: true,
-        source_type: "unknown".to_owned(),
+        kind: "unknown".to_owned(),
     };
     assert_eq!(get_source_info(), expected_source_info);
 
@@ -182,9 +182,9 @@ fn test_create_update_source_custom() {
 }
 
 #[test]
-fn test_create_source_with_type() {
+fn test_create_source_with_kind() {
     let cli = TestCli::get();
-    let source = TestSource::new_args(&["--title=some title", "--source-type=call"]);
+    let source = TestSource::new_args(&["--title=some title", "--kind=call"]);
 
     /// A subset of source fields that we can easily check for equality accross
     #[derive(PartialEq, Eq, Debug)]
@@ -192,7 +192,7 @@ fn test_create_source_with_type() {
         owner: String,
         name: String,
         title: String,
-        source_type: String,
+        kind: String,
     }
 
     impl From<Source> for SourceInfo {
@@ -201,7 +201,7 @@ fn test_create_source_with_type() {
                 owner: source.owner.0,
                 name: source.name.0,
                 title: source.title,
-                source_type: source.source_type.to_string(),
+                kind: source.kind.to_string(),
             }
         }
     }
@@ -215,7 +215,7 @@ fn test_create_source_with_type() {
         owner: source.owner().to_owned(),
         name: source.name().to_owned(),
         title: "some title".to_owned(),
-        source_type: "call".to_owned(),
+        kind: "call".to_owned(),
     };
     assert_eq!(get_source_info(), expected_source_info);
 }


### PR DESCRIPTION
This has changed in the api so changing it here for consistency and to support the source response correctly.