### PR TITLE
github: fix publish workflow to use projects env var

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests
         run: ./scripts/check
         env:
-          REINFER_CLI_TEST_ORG: ${{ secrets.REINFER_CLI_TEST_ORG }}
+          REINFER_CLI_TEST_PROJECT: ${{ secrets.REINFER_CLI_TEST_PROJECT }}
           REINFER_CLI_TEST_TOKEN: ${{ secrets.REINFER_CLI_TEST_TOKEN }}
           REINFER_CLI_TEST_ENDPOINT: ${{ secrets.REINFER_CLI_TEST_ENDPOINT }}
       - name: Install publish dependencies


### PR DESCRIPTION
Someone forgot to change the publish workflow when he changed the variable name :speak_no_evil: 