### PR TITLE
create: trigger-exception

### DIFF
--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -36,6 +36,14 @@ impl FromStr for Id {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct Uid(pub String);
 
+impl FromStr for Uid {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self> {
+        Ok(Self(string.to_owned()))
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct ThreadId(pub String);
 

--- a/api/src/resources/trigger.rs
+++ b/api/src/resources/trigger.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use crate::error::{Error, Result};
 
 use super::{
-    comment::{Comment, CommentFilter, Entity, PredictedLabel},
+    comment::{Comment, CommentFilter, Entity, PredictedLabel, Uid as CommentUid},
     dataset::{FullName as DatasetFullName, Id as DatasetId},
     label_def::Name as LabelName,
 };
@@ -103,4 +103,20 @@ pub(crate) struct AdvanceRequest {
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct ResetRequest {
     pub to_comment_created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct TagExceptionsRequest<'request> {
+    pub exceptions: &'request [TriggerException<'request>],
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriggerException<'request> {
+    pub metadata: TriggerExceptionMetadata<'request>,
+    pub uid: &'request CommentUid,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriggerExceptionMetadata<'request> {
+    pub r#type: &'request String,
 }

--- a/cli/src/commands/create/mod.rs
+++ b/cli/src/commands/create/mod.rs
@@ -5,12 +5,13 @@ mod dataset;
 mod emails;
 mod project;
 mod source;
+mod trigger_exception;
 mod user;
 
 use self::{
     annotations::CreateAnnotationsArgs, bucket::CreateBucketArgs, comments::CreateCommentsArgs,
     dataset::CreateDatasetArgs, emails::CreateEmailsArgs, project::CreateProjectArgs,
-    source::CreateSourceArgs, user::CreateUserArgs,
+    source::CreateSourceArgs, trigger_exception::CreateTriggerExceptionArgs, user::CreateUserArgs,
 };
 use crate::printer::Printer;
 use anyhow::Result;
@@ -50,6 +51,10 @@ pub enum CreateArgs {
     #[structopt(name = "user")]
     /// Create a new user (note: no welcome email will be sent)
     User(CreateUserArgs),
+
+    #[structopt(name = "trigger-exception")]
+    /// Create a new trigger exception
+    TriggerException(CreateTriggerExceptionArgs),
 }
 
 pub fn run(create_args: &CreateArgs, client: Client, printer: &Printer) -> Result<()> {
@@ -62,5 +67,8 @@ pub fn run(create_args: &CreateArgs, client: Client, printer: &Printer) -> Resul
         CreateArgs::Annotations(annotations_args) => annotations::create(&client, annotations_args),
         CreateArgs::Emails(emails_args) => emails::create(&client, emails_args),
         CreateArgs::User(user_args) => user::create(&client, user_args, printer),
+        CreateArgs::TriggerException(trigger_exception_args) => {
+            trigger_exception::create(&client, trigger_exception_args, printer)
+        }
     }
 }

--- a/cli/src/commands/create/trigger_exception.rs
+++ b/cli/src/commands/create/trigger_exception.rs
@@ -1,0 +1,46 @@
+use crate::printer::Printer;
+use anyhow::{Context, Result};
+use log::info;
+use reinfer_client::{
+    Client, CommentUid, TriggerException, TriggerExceptionMetadata, TriggerFullName,
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct CreateTriggerExceptionArgs {
+    #[structopt(short = "t", long = "trigger")]
+    /// The dataset name or id
+    trigger: TriggerFullName,
+
+    #[structopt(long = "type")]
+    /// The type of exception. Please choose a short, easy-to-understand string such as "No Prediction".
+    r#type: String,
+
+    #[structopt(long = "uid")]
+    /// The uid of the comment that should be tagged as an exception.
+    uid: CommentUid,
+}
+
+pub fn create(
+    client: &Client,
+    args: &CreateTriggerExceptionArgs,
+    _printer: &Printer,
+) -> Result<()> {
+    let CreateTriggerExceptionArgs {
+        trigger,
+        r#type,
+        uid,
+    } = args;
+
+    client
+        .tag_trigger_exceptions(
+            trigger,
+            &[TriggerException {
+                metadata: TriggerExceptionMetadata { r#type },
+                uid,
+            }],
+        )
+        .context("Operation to create a trigger exception has failed")?;
+    info!("New trigger exception created successfully");
+    Ok(())
+}


### PR DESCRIPTION
I needed to test trigger exceptions for my filtering refactoring, so thought I'd add to the CLI rather than working out the curl by hand.

Implemented using the :sparkles: amazing :sparkles: API docs here, as I've never touched this code before: https://developers.reinfer.io/api/reference/triggers#tag-an-exception

```log
$ re create trigger-exception --trigger org2/ee-twitter-nps/hello-integration --type "Sad Violin" --uid "64904092030935f4.2211b04b1b6391172965b57e37d5a9cb"
W TLS certificate verification is disabled. Do NOT use this over an insecure network.
I New trigger exception created successfully
```