### PR TITLE
Revert to v0.10.2 links in readmes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.11.0
+# Unreleased
 
 ## Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "reinfer-cli"
-version = "0.11.0"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "reinfer-client"
-version = "0.11.0"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "log",

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ The [api](/api) directory contains a Rust client library for reinfer which can b
 
 Statically linked binaries with no dependencies are provided for selected platforms:
 
-- [Linux (x86_64-unknown-linux-musl)](https://reinfer.io/public/cli/bin/x86_64-unknown-linux-musl/0.11.0/re)
-- [macOS (x86_64-apple-darwin)](https://reinfer.io/public/cli/bin/x86_64-apple-darwin/0.11.0/re)
-- [Windows (x86_64-pc-windows-gnu)](https://reinfer.io/public/cli/bin/x86_64-pc-windows-gnu/0.11.0/re.exe)
+- [Linux (x86_64-unknown-linux-musl)](https://reinfer.io/public/cli/bin/x86_64-unknown-linux-musl/0.10.2/re)
+- [macOS (x86_64-apple-darwin)](https://reinfer.io/public/cli/bin/x86_64-apple-darwin/0.10.2/re)
+- [Windows (x86_64-pc-windows-gnu)](https://reinfer.io/public/cli/bin/x86_64-pc-windows-gnu/0.10.2/re.exe)
 
 ### Debian / Ubuntu
 
-You can download a `.deb` package [here](https://reinfer.io/public/cli/debian/reinfer-cli_0.11.0_amd64.deb).
+You can download a `.deb` package [here](https://reinfer.io/public/cli/debian/reinfer-cli_0.10.2_amd64.deb).
 
 ### From Source
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinfer-client"
-version = "0.11.0"
+version = "0.10.2"
 description = "API client for Re:infer"
 homepage = "https://github.com/reinfer/cli"
 readme = "README.md"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reinfer-cli"
-version = "0.11.0"
+version = "0.10.2"
 description = "Command line interface for the reinfer platform."
 homepage = "https://github.com/reinfer/cli"
 readme = "README.md"
@@ -34,7 +34,7 @@ serde_json = "1.0.64"
 structopt = { version = "0.3.21", default-features = false }
 url = { version = "2.2.2", features = ["serde"] }
 
-reinfer-client = { version = "0.11.0", path = "../api" }
+reinfer-client = { version = "0.10.2", path = "../api" }
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"


### PR DESCRIPTION
v0.11.0 isn't released yet due to failing CI build. So reverting the readme(s) to point to v0.10.2 to fix broken links.