### PR TITLE
cli: show bucket name on get source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Added
 
 - `re create trigger-exception` to tag a comment exception within a trigger.
+- `re get source` and `re get sources` will show bucket name if exists.
 
 ## Bug Fixes
 

--- a/api/src/resources/source.rs
+++ b/api/src/resources/source.rs
@@ -23,6 +23,7 @@ pub struct Source {
     pub should_translate: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub bucket_id: Option<BucketId>,
 
     #[serde(rename = "_kind")]
     pub kind: SourceKind,

--- a/cli/src/printer.rs
+++ b/cli/src/printer.rs
@@ -108,7 +108,7 @@ impl DisplayTable for Project {
 
 impl DisplayTable for Source {
     fn to_table_headers() -> Row {
-        row![bFg => "Name", "ID", "Updated (UTC)", "Title"]
+        row![bFg => "Name", "ID", "Updated (UTC)", "Title", "Bucket ID"]
     }
 
     fn to_table_row(&self) -> Row {
@@ -117,7 +117,45 @@ impl DisplayTable for Source {
             full_name,
             self.id.0,
             self.updated_at.format("%Y-%m-%d %H:%M:%S"),
-            self.title
+            self.title,
+            match &self.bucket_id {
+                Some(bucket_id) => bucket_id.0.as_str().into(),
+                None => "none".dimmed(),
+            }
+        ]
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct EnrichedSource {
+    pub source: Source,
+    pub bucket: Option<Bucket>,
+}
+
+impl DisplayTable for EnrichedSource {
+    fn to_table_headers() -> Row {
+        row![bFg => "Name", "ID", "Updated (UTC)", "Title", "Bucket"]
+    }
+
+    fn to_table_row(&self) -> Row {
+        let full_name = format!(
+            "{}{}{}",
+            self.source.owner.0.dimmed(),
+            "/".dimmed(),
+            self.source.name.0
+        );
+        row![
+            full_name,
+            self.source.id.0,
+            self.source.updated_at.format("%Y-%m-%d %H:%M:%S"),
+            self.source.title,
+            match &self.bucket {
+                Some(bucket) => bucket.name.0.as_str().into(),
+                None => match &self.source.bucket_id {
+                    Some(bucket_id) => bucket_id.0.as_str().dimmed(),
+                    None => "none".dimmed(),
+                },
+            }
         ]
     }
 }


### PR DESCRIPTION
The idea is to show a bucket name if the source is connected to a bucket. In cases where the user can see the source but not the bucket (either bc they don't have permissions to see the bucket, or bc the bucket doesn't exist - example `org1/riley-testuser-mariusreinfer-onmicrosoft-com` on Staging) the bucket ID is shown instead.