### PR TITLE
add project id

### DIFF
--- a/api/src/resources/project.rs
+++ b/api/src/resources/project.rs
@@ -27,8 +27,17 @@ impl FromStr for ProjectName {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+pub struct Id(pub String);
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Project {
+    // CODE HEALTH: At time of addition, deployed versions of reinfer may not
+    // return project ids.
+    //
+    // This can be removed once reinfer is deployed everywhere.
+    #[serde(default)]
+    pub id: Option<Id>,
     pub name: ProjectName,
     pub title: String,
     pub description: String,

--- a/cli/src/printer.rs
+++ b/cli/src/printer.rs
@@ -98,11 +98,18 @@ impl DisplayTable for Dataset {
 
 impl DisplayTable for Project {
     fn to_table_headers() -> Row {
-        row![bFg => "Name", "Title"]
+        row![bFg => "Name", "ID", "Title"]
     }
 
     fn to_table_row(&self) -> Row {
-        row![self.name.0, self.title]
+        row![
+            self.name.0,
+            match &self.id {
+                Some(id) => id.0.as_str().into(),
+                None => "unknown".dimmed(),
+            },
+            self.title
+        ]
     }
 }
 


### PR DESCRIPTION
Future support for showing project ids in `re get projects`.

This is not blocked on the corresponding api PR - it will work with current platform, and future versions where id is returned.