### PR TITLE
github: update config file for publishing action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./scripts/publish-install
         env:
           BUILD_PLATFORM: ${{ matrix.os }}
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@main
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
       - name: Publish Binaries


### PR DESCRIPTION
By the look of it, `google-github-actions/setup-gcloud` have changed `master` to `main`, updating the config to fix this.