### PR TITLE
Allow build github action to be triggered manually

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -47,7 +47,7 @@ impl FromStr for Uid {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct ThreadId(pub String);
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CommentFilter(pub JsonValue);
 
 impl Default for CommentFilter {


### PR DESCRIPTION
This is same way as `publish.yml` is already configured.

I would like to be able to run the build Github action on master to test if it works properly there.