### PR TITLE
api/cli: add update users command (RE-2862)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Added
+
+- `re update users` for bulk user permission updates
+
 # v0.12.1
 
 ## Added

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -52,7 +52,7 @@ use crate::resources::{
     user::{
         CreateRequest as CreateUserRequest, CreateResponse as CreateUserResponse,
         GetAvailableResponse as GetAvailableUsersResponse,
-        GetCurrentResponse as GetCurrentUserResponse,
+        GetCurrentResponse as GetCurrentUserResponse, PostUserRequest, PostUserResponse,
     },
     EmptySuccess, Response,
 };
@@ -98,7 +98,7 @@ pub use crate::{
         },
         user::{
             Email, GlobalPermission, Id as UserId, Identifier as UserIdentifier,
-            ModifiedPermissions, NewUser, ProjectPermission, User, Username,
+            ModifiedPermissions, NewUser, ProjectPermission, UpdateUser, User, Username,
         },
     },
 };
@@ -347,6 +347,14 @@ impl Client {
         self.put(
             self.endpoints.put_emails(bucket_name)?,
             PutEmailsRequest { emails },
+        )
+    }
+
+    pub fn post_user(&self, user_id: &UserId, user: UpdateUser) -> Result<PostUserResponse> {
+        self.post(
+            self.endpoints.post_user(user_id)?,
+            PostUserRequest { user: &user },
+            Retry::Yes,
         )
     }
 
@@ -1257,6 +1265,15 @@ impl Endpoints {
                     "Could not build put emails URL for bucket `{}`.",
                     bucket_name,
                 ),
+            })
+    }
+
+    fn post_user(&self, user_id: &UserId) -> Result<Url> {
+        self.base
+            .join(&format!("/api/_private/users/{}", user_id.0))
+            .map_err(|source| Error::UrlParseError {
+                source,
+                message: format!("Could not build post user URL for user `{}`.", user_id.0,),
             })
     }
 

--- a/api/src/resources/user.rs
+++ b/api/src/resources/user.rs
@@ -265,6 +265,25 @@ impl FromStr for GlobalPermission {
     }
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, Deserialize)]
+pub struct UpdateUser {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organisation_permissions: Option<HashMap<ProjectName, Vec<ProjectPermission>>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub global_permissions: Option<Vec<GlobalPermission>>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct PostUserRequest<'request> {
+    pub user: &'request UpdateUser,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PostUserResponse {
+    pub user: User,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cli/src/commands/update/mod.rs
+++ b/cli/src/commands/update/mod.rs
@@ -1,8 +1,12 @@
 mod dataset;
 mod project;
 mod source;
+mod users;
 
-use self::{dataset::UpdateDatasetArgs, project::UpdateProjectArgs, source::UpdateSourceArgs};
+use self::{
+    dataset::UpdateDatasetArgs, project::UpdateProjectArgs, source::UpdateSourceArgs,
+    users::UpdateUsersArgs,
+};
 use crate::printer::Printer;
 use anyhow::Result;
 use reinfer_client::Client;
@@ -21,6 +25,10 @@ pub enum UpdateArgs {
     #[structopt(name = "project")]
     /// Update an existing project
     Project(UpdateProjectArgs),
+
+    #[structopt(name = "users")]
+    /// Update existing users
+    Users(UpdateUsersArgs),
 }
 
 pub fn run(update_args: &UpdateArgs, client: Client, printer: &Printer) -> Result<()> {
@@ -28,5 +36,6 @@ pub fn run(update_args: &UpdateArgs, client: Client, printer: &Printer) -> Resul
         UpdateArgs::Source(source_args) => source::update(&client, source_args, printer),
         UpdateArgs::Dataset(dataset_args) => dataset::update(&client, dataset_args, printer),
         UpdateArgs::Project(project_args) => project::update(&client, project_args, printer),
+        UpdateArgs::Users(users_args) => users::update(&client, users_args),
     }
 }

--- a/cli/src/commands/update/users.rs
+++ b/cli/src/commands/update/users.rs
@@ -1,0 +1,162 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+use log::info;
+use reinfer_client::{Client, UpdateUser, UserId};
+use std::{
+    fs::{self, File},
+    io::{self, BufRead, BufReader},
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use structopt::StructOpt;
+
+use crate::progress::{Options as ProgressOptions, Progress};
+
+#[derive(Debug, StructOpt)]
+pub struct UpdateUsersArgs {
+    #[structopt(short = "f", long = "file", parse(from_os_str))]
+    /// Path to JSON file with users. If not specified, stdin will be used.
+    input_file: Option<PathBuf>,
+
+    #[structopt(long)]
+    /// Don't display a progress bar (only applicable when --file is used).
+    no_progress: bool,
+}
+
+pub fn update(client: &Client, args: &UpdateUsersArgs) -> Result<()> {
+    let statistics = match &args.input_file {
+        Some(input_file) => {
+            info!("Processing users from file `{}`", input_file.display(),);
+            let file_metadata = fs::metadata(&input_file).with_context(|| {
+                format!("Could not get file metadata for `{}`", input_file.display())
+            })?;
+            let file = BufReader::new(
+                File::open(input_file)
+                    .with_context(|| format!("Could not open file `{}`", input_file.display()))?,
+            );
+            let statistics = Arc::new(Statistics::new());
+            let progress = if args.no_progress {
+                None
+            } else {
+                Some(progress_bar(file_metadata.len(), &statistics))
+            };
+            update_users_from_reader(client, file, &statistics)?;
+            if let Some(mut progress) = progress {
+                progress.done();
+            }
+            Arc::try_unwrap(statistics).unwrap()
+        }
+        None => {
+            info!("Processing users from stdin",);
+            let statistics = Statistics::new();
+            update_users_from_reader(client, BufReader::new(io::stdin()), &statistics)?;
+            statistics
+        }
+    };
+
+    info!(
+        concat!("Successfully updated {} users",),
+        statistics.num_updated(),
+    );
+
+    Ok(())
+}
+
+use serde::{self, Deserialize, Serialize};
+#[derive(Serialize, Deserialize)]
+struct UserLine {
+    id: UserId,
+
+    #[serde(flatten)]
+    update: UpdateUser,
+}
+
+fn update_users_from_reader(
+    client: &Client,
+    mut users: impl BufRead,
+    statistics: &Statistics,
+) -> Result<()> {
+    let mut line_number = 1;
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes_read = users
+            .read_line(&mut line)
+            .with_context(|| format!("Could not read line {} from input stream", line_number))?;
+
+        if bytes_read == 0 {
+            return Ok(());
+        }
+
+        statistics.add_bytes_read(bytes_read);
+        let user_line = serde_json::from_str::<UserLine>(line.trim_end()).with_context(|| {
+            format!(
+                "Could not parse user at line {} from input stream",
+                line_number,
+            )
+        })?;
+
+        // Upload users
+        client
+            .post_user(&user_line.id, user_line.update)
+            .context("Could not update user")?;
+        statistics.add_user();
+
+        line_number += 1;
+    }
+}
+
+#[derive(Debug)]
+pub struct Statistics {
+    bytes_read: AtomicUsize,
+    updated: AtomicUsize,
+}
+
+impl Statistics {
+    fn new() -> Self {
+        Self {
+            bytes_read: AtomicUsize::new(0),
+            updated: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline]
+    fn add_bytes_read(&self, bytes_read: usize) {
+        self.bytes_read.fetch_add(bytes_read, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_user(&self) {
+        self.updated.fetch_add(1, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn bytes_read(&self) -> usize {
+        self.bytes_read.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn num_updated(&self) -> usize {
+        self.updated.load(Ordering::SeqCst)
+    }
+}
+
+fn progress_bar(total_bytes: u64, statistics: &Arc<Statistics>) -> Progress {
+    Progress::new(
+        move |statistics| {
+            let bytes_read = statistics.bytes_read();
+            let num_updated = statistics.num_updated();
+            (
+                bytes_read as u64,
+                format!("{} {}", num_updated.to_string().bold(), "users".dimmed()),
+            )
+        },
+        statistics,
+        Some(total_bytes),
+        ProgressOptions { bytes_units: true },
+    )
+}


### PR DESCRIPTION
For https://reinfer.atlassian.net/browse/RE-2862

Adds a bulk update for user objects.

Example usage: update all users who have the `alerts-write` or `alerts-read` permissions in any project, to not have them.

```bash
# Get all visible users
cargo run -- -o json get users > users.jsonl
# Generate an update using some jq magic
cat users.jsonl | jq -rc '. as $user | .organisation_permissions | map_values(select(any(. == "alerts-write" or . == "alerts-read")) | map(select(. != "alerts-write" and . != "alerts-read"))) | select(length > 0) | {"id": $user.id, "organisation_permissions": . }' > updated_users.jsonl
# Check the updates to be applied
bat updated_users.jsonl
# Store the updated users
cargo run -- update users -f updated_users.jsonl
```

Tested against local data.