### PR TITLE
api/cli: upgrade dependencies and rustc to 1.65.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,45 +10,33 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "android_system_properties"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "winapi",
+ "libc",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
-
-[[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "assert-json-diff"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f1c3703dd33532d7f0ca049168930e9099ecac238e23cf932f3a69c42f06da"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
@@ -56,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
 dependencies = [
  "flate2",
  "futures-core",
@@ -86,26 +74,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "bstr"
@@ -121,27 +98,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 
 [[package]]
 name = "cfg-if"
@@ -151,15 +122,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -171,6 +144,16 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
  "textwrap",
+ "unicode-width",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
  "unicode-width",
 ]
 
@@ -187,22 +170,16 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "winapi",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -230,16 +207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,19 +230,63 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.22"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.4"
+name = "cxx"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -283,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -297,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
@@ -308,20 +319,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
-
-[[package]]
-name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users 0.3.5",
- "winapi",
-]
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dirs"
@@ -333,13 +333,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users 0.4.3",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
  "winapi",
 ]
 
@@ -348,6 +369,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -360,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -373,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -413,52 +440,51 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -471,20 +497,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -493,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -512,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -535,6 +550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,7 +563,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.2",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -558,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -576,9 +597,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -589,7 +610,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.2",
+ "itoa 1.0.4",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -612,6 +633,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,23 +664,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -673,15 +718,15 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -694,9 +739,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "log"
@@ -712,12 +766,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -743,23 +791,23 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -782,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -819,11 +867,20 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -835,15 +892,15 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -873,18 +930,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.20.0+1.1.1o"
+version = "111.24.0+1.1.1s"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92892c4f87d56e376e469ace79f1128fdaded07646ddf73aa0be4706ff712dec"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -896,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.0.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2"
+checksum = "1f74e330193f90ec45e2b257fa3ef6df087784157ac1ad2c1e71c62837b03aa7"
 dependencies = [
  "num-traits",
  "serde",
@@ -915,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
@@ -933,9 +990,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "ppv-lite86"
@@ -945,25 +1002,25 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "pretty_assertions"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
 dependencies = [
- "ansi_term",
  "ctor",
  "diff",
  "output_vt100",
+ "yansi",
 ]
 
 [[package]]
 name = "prettytable-rs"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+checksum = "5f375cb74c23b51d23937ffdeb48b1fbf5b6409d4b9979c1418c1de58bc8f801"
 dependencies = [
  "atty",
  "csv",
- "encode_unicode",
+ "encode_unicode 1.0.0",
  "lazy_static",
  "term",
  "unicode-width",
@@ -995,18 +1052,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -1034,37 +1091,20 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
 ]
 
 [[package]]
@@ -1073,16 +1113,16 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.7",
- "redox_syscall 0.2.13",
+ "getrandom",
+ "redox_syscall",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1097,9 +1137,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "reinfer-cli"
@@ -1108,7 +1148,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "colored",
- "dirs 4.0.0",
+ "dirs",
  "env_logger",
  "indicatif",
  "log",
@@ -1155,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "async-compression",
  "base64",
@@ -1172,11 +1212,11 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "mime_guess",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -1194,22 +1234,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.3"
+name = "rustversion"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
-]
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "schannel"
@@ -1218,14 +1252,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.6.1"
+name = "scratch"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1246,18 +1286,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1266,11 +1306,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -1282,26 +1322,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.2",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
 dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
  "serde",
+ "serde_json",
  "serde_with_macros",
+ "time 0.3.16",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1311,21 +1357,24 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -1363,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1381,19 +1430,19 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "libc",
- "redox_syscall 0.2.13",
+ "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
 
 [[package]]
 name = "term"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "byteorder",
- "dirs 1.0.5",
+ "dirs-next",
+ "rustversion",
  "winapi",
 ]
 
@@ -1427,18 +1476,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1454,6 +1503,35 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+dependencies = [
+ "itoa 1.0.4",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -1473,16 +1551,16 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "socket2",
  "winapi",
@@ -1500,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1520,9 +1598,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1531,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
 ]
@@ -1561,51 +1639,50 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
  "serde",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
@@ -1632,12 +1709,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
@@ -1650,9 +1721,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1660,13 +1731,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1675,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1687,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1697,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1710,15 +1781,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1761,12 +1832,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1775,10 +1867,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1787,16 +1891,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"
@@ -1806,3 +1934,9 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,17 +12,17 @@ edition = "2021"
 name = "reinfer_client"
 
 [dependencies]
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "0.4.22", features = ["serde"] }
 log = "0.4.17"
-once_cell = "1.12.0"
-ordered-float = { version = "3.0.0", features = ["serde"] }
-regex = "1.5.6"
-reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "gzip", "json", "multipart", "native-tls-vendored"] }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-serde_with = "1.14.0"
-thiserror = "1.0.31"
-url = "2.2.2"
+once_cell = "1.16.0"
+ordered-float = { version = "3.3.0", features = ["serde"] }
+regex = "1.6.0"
+reqwest = { version = "0.11.12", default-features = false, features = ["blocking", "gzip", "json", "multipart", "native-tls-vendored"] }
+serde = { version = "1.0.147", features = ["derive"] }
+serde_json = "1.0.87"
+serde_with = "2.0.1"
+thiserror = "1.0.37"
+url = "2.3.1"
 
 [dev-dependencies]
 mockito = "0.31.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,28 +17,28 @@ path = "src/main.rs"
 name = "tests"
 
 [dependencies]
-anyhow = "1.0.58"
-chrono = "0.4.19"
+anyhow = "1.0.66"
+chrono = "0.4.22"
 colored = "2.0.0"
 dirs = "4.0.0"
-env_logger = "0.9.0"
+env_logger = "0.9.1"
 indicatif = "0.16.2"
 log = { version = "0.4.17", default-features = false, features = ["release_max_level_info"] }
 maplit = "1.0.2"
-once_cell = "1.12.0"
-prettytable-rs = "0.8.0"
-regex = "1.5.6"
-reqwest = { version = "0.11.11", default-features = false }
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
+once_cell = "1.16.0"
+prettytable-rs = "0.9.0"
+regex = "1.6.0"
+reqwest = { version = "0.11.12", default-features = false }
+serde = { version = "1.0.147", features = ["derive"] }
+serde_json = "1.0.87"
 structopt = { version = "0.3.26", default-features = false }
-url = { version = "2.2.2", features = ["serde"] }
+url = { version = "2.3.1", features = ["serde"] }
 
 reinfer-client = { version = "0.12.0", path = "../api" }
 
 [dev-dependencies]
-pretty_assertions = "1.2.1"
-uuid = { version = "1.1.2", features = ["v4"] }
+pretty_assertions = "1.3.0"
+uuid = { version = "1.2.1", features = ["v4"] }
 
 [features]
 default = []

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -1,6 +1,6 @@
 use colored::Colorize;
 use log::{error, info, warn};
-use prettytable::{self, cell, row, Table};
+use prettytable::{self, row, Table};
 use reinfer_client::DEFAULT_ENDPOINT;
 use reqwest::Url;
 use std::path::Path;

--- a/cli/src/commands/create/emails.rs
+++ b/cli/src/commands/create/emails.rs
@@ -47,7 +47,7 @@ pub fn create(client: &Client, args: &CreateEmailsArgs) -> Result<()> {
                 bucket.full_name(),
                 bucket.id,
             );
-            let file_metadata = fs::metadata(&emails_path).with_context(|| {
+            let file_metadata = fs::metadata(emails_path).with_context(|| {
                 format!(
                     "Could not get file metadata for `{}`",
                     emails_path.display()

--- a/cli/src/printer.rs
+++ b/cli/src/printer.rs
@@ -1,5 +1,5 @@
 use colored::Colorize;
-use prettytable::{cell, format, row, Row, Table};
+use prettytable::{format, row, Row, Table};
 use reinfer_client::{Bucket, Dataset, Project, Source, Trigger, User};
 use serde::{Serialize, Serializer};
 

--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -38,7 +38,7 @@ impl TestCli {
     }
 
     pub fn user(&self) -> User {
-        let output = self.run(&["--output=json", "get", "current-user"]);
+        let output = self.run(["--output=json", "get", "current-user"]);
         serde_json::from_str::<User>(&output).expect("Failed to deserialize user response")
     }
 

--- a/cli/tests/test_buckets.rs
+++ b/cli/tests/test_buckets.rs
@@ -9,7 +9,7 @@ fn test_bucket_lifecycle() {
     let new_bucket_name = format!("{}/test-source-{}", owner, Uuid::new_v4());
 
     // Create bucket
-    let output = cli.run(&[
+    let output = cli.run([
         "create",
         "bucket",
         &new_bucket_name,
@@ -18,14 +18,14 @@ fn test_bucket_lifecycle() {
     ]);
     assert!(output.contains(&new_bucket_name), "{}", output);
 
-    let output = cli.run(&["get", "buckets"]);
+    let output = cli.run(["get", "buckets"]);
     assert!(output.contains(&new_bucket_name), "{}", output);
 
     // Deleting one comment reduces the comment count in the source
-    let output = cli.run(&["delete", "bucket", &new_bucket_name]);
+    let output = cli.run(["delete", "bucket", &new_bucket_name]);
     assert!(output.is_empty(), "{}", output);
 
-    let output = cli.run(&["get", "buckets"]);
+    let output = cli.run(["get", "buckets"]);
     assert!(!output.contains(&new_bucket_name), "{}", output);
 }
 
@@ -36,7 +36,7 @@ fn test_bucket_with_invalid_transform_tag_fails() {
 
     let new_bucket_name = format!("{}/test-source-{}", owner, Uuid::new_v4());
 
-    let output = cli.run_and_error(&[
+    let output = cli.run_and_error([
         "create",
         "bucket",
         &new_bucket_name,
@@ -56,7 +56,7 @@ fn test_bucket_with_invalid_transform_tag_fails() {
 fn test_create_without_org_fails() {
     let cli = TestCli::get();
 
-    let output = cli.run_and_error(&[
+    let output = cli.run_and_error([
         "create",
         "bucket",
         "bucket-name-without-org",
@@ -74,7 +74,7 @@ fn test_create_without_org_fails() {
 fn test_create_with_empty_org_fails() {
     let cli = TestCli::get();
 
-    let output = cli.run_and_error(&[
+    let output = cli.run_and_error([
         "create",
         "bucket",
         "/bucket-name-with-empty-org",
@@ -92,7 +92,7 @@ fn test_create_with_empty_org_fails() {
 fn test_create_with_empty_bucket_name_fails() {
     let cli = TestCli::get();
 
-    let output = cli.run_and_error(&[
+    let output = cli.run_and_error([
         "create",
         "bucket",
         "org-without-bucket-name/",
@@ -110,7 +110,7 @@ fn test_create_with_empty_bucket_name_fails() {
 fn test_create_with_too_many_seperators_fails() {
     let cli = TestCli::get();
 
-    let output = cli.run_and_error(&[
+    let output = cli.run_and_error([
         "create",
         "bucket",
         "Bucket/Name/with/too/many/seperators/",

--- a/cli/tests/test_comments.rs
+++ b/cli/tests/test_comments.rs
@@ -63,12 +63,12 @@ fn check_comments_lifecycle(comments_str: &str, args: Vec<&str>) {
     );
     assert!(output.is_empty());
 
-    let output = cli.run(&["get", "comments", source.identifier()]);
+    let output = cli.run(["get", "comments", source.identifier()]);
     assert_eq!(output.lines().count(), annotated_comments.len());
 
     // Test getting a comment by id to check the content matches
     let test_comment = annotated_comments.get(0).unwrap().comment.clone();
-    let output = cli.run(&[
+    let output = cli.run([
         "get",
         "comment",
         &format!("--source={}", source.identifier()),
@@ -85,7 +85,7 @@ fn check_comments_lifecycle(comments_str: &str, args: Vec<&str>) {
     );
 
     // Deleting one comment reduces the comment count in the source
-    let output = cli.run(&[
+    let output = cli.run([
         "delete",
         "comments",
         &format!("--source={}", source.identifier()),
@@ -93,7 +93,7 @@ fn check_comments_lifecycle(comments_str: &str, args: Vec<&str>) {
     ]);
     assert!(output.is_empty());
 
-    let output = cli.run(&["get", "comments", source.identifier()]);
+    let output = cli.run(["get", "comments", source.identifier()]);
     assert_eq!(output.lines().count(), annotated_comments.len() - 1);
 
     // Delete all ids
@@ -106,7 +106,7 @@ fn check_comments_lifecycle(comments_str: &str, args: Vec<&str>) {
     let output = cli.run(&args);
     assert!(output.is_empty());
 
-    let output = cli.run(&["get", "comments", source.identifier()]);
+    let output = cli.run(["get", "comments", source.identifier()]);
     assert!(output.is_empty());
 }
 
@@ -130,7 +130,7 @@ fn test_delete_comments_in_range() {
 
     // Upload our test data
     let output = cli.run_with_stdin(
-        &[
+        [
             "create",
             "comments",
             "--allow-duplicates",
@@ -141,11 +141,11 @@ fn test_delete_comments_in_range() {
     );
     assert!(output.is_empty());
 
-    let uploaded_all = cli.run(&["get", "comments", source.identifier()]);
+    let uploaded_all = cli.run(["get", "comments", source.identifier()]);
     assert_eq!(uploaded_all.lines().count(), num_comments);
 
     // Download annotated comments and check count
-    let uploaded_annotated = cli.run(&[
+    let uploaded_annotated = cli.run([
         "get",
         "comments",
         "--reviewed-only",
@@ -163,7 +163,7 @@ fn test_delete_comments_in_range() {
     let to_timestamp_str = "2020-02-01T00:00:00Z";
     let to_timestamp = DateTime::parse_from_rfc3339(to_timestamp_str).unwrap();
 
-    cli.run(&[
+    cli.run([
         "delete",
         "bulk",
         "--source",
@@ -185,7 +185,7 @@ fn test_delete_comments_in_range() {
         .count();
 
     // Get all comments and check counts
-    let after_deleting_range = cli.run(&[
+    let after_deleting_range = cli.run([
         "get",
         "comments",
         "--dataset",
@@ -198,7 +198,7 @@ fn test_delete_comments_in_range() {
     );
 
     // Delete comments in source, excluding annotated comments
-    cli.run(&[
+    cli.run([
         "delete",
         "bulk",
         "--source",
@@ -207,7 +207,7 @@ fn test_delete_comments_in_range() {
     ]);
 
     // Get all comments and check that only annotated ones are left
-    let after_deleting_unannotated = cli.run(&[
+    let after_deleting_unannotated = cli.run([
         "get",
         "comments",
         "--dataset",
@@ -217,7 +217,7 @@ fn test_delete_comments_in_range() {
     assert_eq!(after_deleting_unannotated.lines().count(), num_annotated);
 
     // Delete all comments
-    cli.run(&[
+    cli.run([
         "delete",
         "bulk",
         &format!("--source={}", source.identifier()),
@@ -225,7 +225,7 @@ fn test_delete_comments_in_range() {
     ]);
 
     // Get all comments and check there are none left
-    let after_deleting_all = cli.run(&[
+    let after_deleting_all = cli.run([
         "get",
         "comments",
         "--dataset",

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -20,7 +20,7 @@ impl TestDataset {
         let full_name = format!("{}/test-dataset-{}", user, Uuid::new_v4());
         let sep_index = user.len();
 
-        let output = cli.run(&["create", "dataset", &full_name]);
+        let output = cli.run(["create", "dataset", &full_name]);
         assert!(output.contains(&full_name));
 
         Self {
@@ -59,7 +59,7 @@ impl TestDataset {
 
 impl Drop for TestDataset {
     fn drop(&mut self) {
-        let output = TestCli::get().run(&["delete", "dataset", self.identifier()]);
+        let output = TestCli::get().run(["delete", "dataset", self.identifier()]);
         assert!(output.is_empty());
     }
 }
@@ -70,13 +70,13 @@ fn test_test_dataset() {
     let dataset = TestDataset::new();
     let identifier = dataset.identifier().to_owned();
 
-    let output = cli.run(&["get", "datasets"]);
+    let output = cli.run(["get", "datasets"]);
     assert!(output.contains(&identifier));
 
     drop(dataset);
 
     // RAII TestDataset; should automatically clean up the temporary dataset on drop.
-    let output = cli.run(&["get", "datasets"]);
+    let output = cli.run(["get", "datasets"]);
     assert!(!output.contains(&identifier));
 }
 
@@ -86,15 +86,15 @@ fn test_list_multiple_datasets() {
     let dataset1 = TestDataset::new();
     let dataset2 = TestDataset::new();
 
-    let output = cli.run(&["get", "datasets"]);
+    let output = cli.run(["get", "datasets"]);
     assert!(output.contains(dataset1.identifier()));
     assert!(output.contains(dataset2.identifier()));
 
-    let output = cli.run(&["get", "datasets", dataset1.identifier()]);
+    let output = cli.run(["get", "datasets", dataset1.identifier()]);
     assert!(output.contains(dataset1.identifier()));
     assert!(!output.contains(dataset2.identifier()));
 
-    let output = cli.run(&["get", "datasets", dataset2.identifier()]);
+    let output = cli.run(["get", "datasets", dataset2.identifier()]);
     assert!(!output.contains(dataset1.identifier()));
     assert!(output.contains(dataset2.identifier()));
 }
@@ -197,7 +197,7 @@ fn test_create_update_dataset_custom() {
     }
 
     let get_dataset_info = || -> DatasetInfo {
-        let output = cli.run(&["--output=json", "get", "datasets", dataset.identifier()]);
+        let output = cli.run(["--output=json", "get", "datasets", dataset.identifier()]);
         serde_json::from_str::<Dataset>(&output).unwrap().into()
     };
 
@@ -259,7 +259,7 @@ fn test_create_update_dataset_custom() {
     assert_eq!(get_dataset_info(), expected_dataset_info);
 
     // Partial update
-    cli.run(&[
+    cli.run([
         "update",
         "dataset",
         "--title=updated title",
@@ -271,7 +271,7 @@ fn test_create_update_dataset_custom() {
     // Should be able to update all fields
     let test_source = TestSource::new();
     let source = test_source.get();
-    cli.run(&[
+    cli.run([
         "update",
         "dataset",
         "--title=updated title",
@@ -286,11 +286,11 @@ fn test_create_update_dataset_custom() {
     assert_eq!(get_dataset_info(), expected_dataset_info);
 
     // An empty update should be fine, including leaving source ids untouched
-    cli.run(&["update", "dataset", dataset.identifier()]);
+    cli.run(["update", "dataset", dataset.identifier()]);
     assert_eq!(get_dataset_info(), expected_dataset_info);
 
     // Setting the sources flag with no ids should clear sources
-    cli.run(&["update", "dataset", dataset.identifier(), "--source"]);
+    cli.run(["update", "dataset", dataset.identifier(), "--source"]);
     expected_dataset_info.source_ids = vec![];
     assert_eq!(get_dataset_info(), expected_dataset_info);
 }
@@ -301,13 +301,13 @@ fn test_create_dataset_with_source() {
     let source = TestSource::new();
     let dataset = TestDataset::new_args(&[&format!("--source={}", source.identifier())]);
 
-    let output = cli.run(&["--output=json", "get", "datasets", dataset.identifier()]);
+    let output = cli.run(["--output=json", "get", "datasets", dataset.identifier()]);
     let dataset_info: Dataset = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(&dataset_info.owner.0, dataset.owner());
     assert_eq!(&dataset_info.name.0, dataset.name());
     assert_eq!(dataset_info.source_ids.len(), 1);
 
-    let source_output = cli.run(&[
+    let source_output = cli.run([
         "--output=json",
         "get",
         "sources",
@@ -324,7 +324,7 @@ fn test_create_dataset_requires_owner() {
 
     let output = cli
         .command()
-        .args(&["create", "dataset", "dataset-without-owner"])
+        .args(["create", "dataset", "dataset-without-owner"])
         .output()
         .unwrap();
 
@@ -336,7 +336,7 @@ fn test_create_dataset_model_family() {
     let cli = TestCli::get();
     let dataset = TestDataset::new_args(&["--model-family==german"]);
 
-    let output = cli.run(&["--output=json", "get", "datasets", dataset.identifier()]);
+    let output = cli.run(["--output=json", "get", "datasets", dataset.identifier()]);
     let dataset_info: Dataset = serde_json::from_str(output.trim()).unwrap();
     assert_eq!(&dataset_info.owner.0, dataset.owner());
     assert_eq!(&dataset_info.name.0, dataset.name());
@@ -348,7 +348,7 @@ fn test_create_dataset_wrong_model_family() {
     let cli = TestCli::get();
     let output = cli
         .command()
-        .args(&[
+        .args([
             "create",
             "dataset",
             "--model-family==non-existent-family",
@@ -365,12 +365,12 @@ fn test_create_dataset_wrong_model_family() {
 fn test_create_dataset_copy_annotations() {
     let cli = TestCli::get();
     let dataset1 = TestDataset::new();
-    let dataset1_output = cli.run(&["--output=json", "get", "datasets", dataset1.identifier()]);
+    let dataset1_output = cli.run(["--output=json", "get", "datasets", dataset1.identifier()]);
     let dataset1_info: Dataset = serde_json::from_str(dataset1_output.trim()).unwrap();
 
     let output = cli
         .command()
-        .args(&[
+        .args([
             "create",
             "dataset",
             &format!("--copy-annotations-from={}", dataset1_info.id.0),

--- a/cli/tests/test_projects.rs
+++ b/cli/tests/test_projects.rs
@@ -40,7 +40,7 @@ impl TestProject {
 
 impl Drop for TestProject {
     fn drop(&mut self) {
-        let output = TestCli::get().run(&["delete", "project", self.name(), "--force"]);
+        let output = TestCli::get().run(["delete", "project", self.name(), "--force"]);
         assert!(output.is_empty());
     }
 }
@@ -52,13 +52,13 @@ fn test_test_project() {
 
     let name = project.name().to_owned();
 
-    let output = cli.run(&["get", "projects"]);
+    let output = cli.run(["get", "projects"]);
     assert!(output.contains(&name));
 
     drop(project);
 
     // RAII TestProject; should automatically clean up the temporary project on drop.
-    let output = cli.run(&["get", "projects"]);
+    let output = cli.run(["get", "projects"]);
     assert!(!output.contains(&name));
 }
 
@@ -68,15 +68,15 @@ fn test_list_multiple_projects() {
     let project1 = TestProject::new();
     let project2 = TestProject::new();
 
-    let output = cli.run(&["get", "projects"]);
+    let output = cli.run(["get", "projects"]);
     assert!(output.contains(project1.name()));
     assert!(output.contains(project2.name()));
 
-    let output = cli.run(&["get", "projects", project1.name()]);
+    let output = cli.run(["get", "projects", project1.name()]);
     assert!(output.contains(project1.name()));
     assert!(!output.contains(project2.name()));
 
-    let output = cli.run(&["get", "projects", project2.name()]);
+    let output = cli.run(["get", "projects", project2.name()]);
     assert!(!output.contains(project1.name()));
     assert!(output.contains(project2.name()));
 }
@@ -105,7 +105,7 @@ fn test_create_update_project_custom() {
     }
 
     let get_project_info = || -> ProjectInfo {
-        let output = cli.run(&["--output=json", "get", "projects", project.name()]);
+        let output = cli.run(["--output=json", "get", "projects", project.name()]);
         serde_json::from_str::<Project>(&output).unwrap().into()
     };
 
@@ -117,16 +117,16 @@ fn test_create_update_project_custom() {
     assert_eq!(get_project_info(), expected_project_info);
 
     // An empty update should be fine
-    cli.run(&["update", "project", project.name()]);
+    cli.run(["update", "project", project.name()]);
     assert_eq!(get_project_info(), expected_project_info);
 
     // Partial update
-    cli.run(&["update", "project", "--title=updated title", project.name()]);
+    cli.run(["update", "project", "--title=updated title", project.name()]);
     expected_project_info.title = "updated title".to_owned();
     assert_eq!(get_project_info(), expected_project_info);
 
     // Should be able to update all fields
-    cli.run(&[
+    cli.run([
         "update",
         "project",
         "--title=updated title for second time",
@@ -146,13 +146,13 @@ fn test_project_force_delete() {
     let name = project.name().to_owned();
     let source_name = format!("{}/a-source", name);
 
-    cli.run(&["create", "source", &source_name]);
+    cli.run(["create", "source", &source_name]);
 
     // Regular delete fails because of the source
 
     let output = cli
         .command()
-        .args(&["delete", "project", &name])
+        .args(["delete", "project", &name])
         .output()
         .unwrap();
     assert!(!output.status.success());
@@ -165,16 +165,16 @@ fn test_project_force_delete() {
 
     // The project still exists
 
-    let output = cli.run(&["get", "projects"]);
+    let output = cli.run(["get", "projects"]);
     assert!(output.contains(&name));
 
     // Force delete succeeds
 
-    cli.run(&["delete", "project", &name, "--force"]);
+    cli.run(["delete", "project", &name, "--force"]);
 
     // The project no longer exists
 
-    let output = cli.run(&["get", "projects"]);
+    let output = cli.run(["get", "projects"]);
     assert!(!output.contains(&name));
 
     // To avoid panic on drop because the project has already been deleted.

--- a/cli/tests/test_sources.rs
+++ b/cli/tests/test_sources.rs
@@ -15,7 +15,7 @@ impl TestSource {
         let full_name = format!("{}/test-source-{}", project_name, Uuid::new_v4());
         let sep_index = project_name.len();
 
-        let output = cli.run(&["create", "source", &full_name]);
+        let output = cli.run(["create", "source", &full_name]);
         assert!(output.contains(&full_name));
 
         Self {
@@ -52,14 +52,14 @@ impl TestSource {
     }
 
     pub fn get(&self) -> Source {
-        let output = TestCli::get().run(&["--output=json", "get", "sources", self.identifier()]);
+        let output = TestCli::get().run(["--output=json", "get", "sources", self.identifier()]);
         serde_json::from_str::<Source>(&output).unwrap()
     }
 }
 
 impl Drop for TestSource {
     fn drop(&mut self) {
-        let output = TestCli::get().run(&["delete", "source", self.identifier()]);
+        let output = TestCli::get().run(["delete", "source", self.identifier()]);
         assert!(output.is_empty());
     }
 }
@@ -71,13 +71,13 @@ fn test_test_source() {
 
     let identifier = source.identifier().to_owned();
 
-    let output = cli.run(&["get", "sources"]);
+    let output = cli.run(["get", "sources"]);
     assert!(output.contains(&identifier));
 
     drop(source);
 
     // RAII TestSource; should automatically clean up the temporary source on drop.
-    let output = cli.run(&["get", "sources"]);
+    let output = cli.run(["get", "sources"]);
     assert!(!output.contains(&identifier));
 }
 
@@ -87,15 +87,15 @@ fn test_list_multiple_sources() {
     let source1 = TestSource::new();
     let source2 = TestSource::new();
 
-    let output = cli.run(&["get", "sources"]);
+    let output = cli.run(["get", "sources"]);
     assert!(output.contains(source1.identifier()));
     assert!(output.contains(source2.identifier()));
 
-    let output = cli.run(&["get", "sources", source1.identifier()]);
+    let output = cli.run(["get", "sources", source1.identifier()]);
     assert!(output.contains(source1.identifier()));
     assert!(!output.contains(source2.identifier()));
 
-    let output = cli.run(&["get", "sources", source2.identifier()]);
+    let output = cli.run(["get", "sources", source2.identifier()]);
     assert!(!output.contains(source1.identifier()));
     assert!(output.contains(source2.identifier()));
 }
@@ -137,7 +137,7 @@ fn test_create_update_source_custom() {
     }
 
     let get_source_info = || -> SourceInfo {
-        let output = cli.run(&["--output=json", "get", "sources", source.identifier()]);
+        let output = cli.run(["--output=json", "get", "sources", source.identifier()]);
         serde_json::from_str::<Source>(&output).unwrap().into()
     };
 
@@ -153,11 +153,11 @@ fn test_create_update_source_custom() {
     assert_eq!(get_source_info(), expected_source_info);
 
     // An empty update should be fine
-    cli.run(&["update", "source", source.identifier()]);
+    cli.run(["update", "source", source.identifier()]);
     assert_eq!(get_source_info(), expected_source_info);
 
     // Partial update
-    cli.run(&[
+    cli.run([
         "update",
         "source",
         "--title=updated title",
@@ -167,7 +167,7 @@ fn test_create_update_source_custom() {
     assert_eq!(get_source_info(), expected_source_info);
 
     // Should be able to update all fields
-    cli.run(&[
+    cli.run([
         "update",
         "source",
         "--title=updated title",
@@ -207,7 +207,7 @@ fn test_create_source_with_kind() {
     }
 
     let get_source_info = || -> SourceInfo {
-        let output = cli.run(&["--output=json", "get", "sources", source.identifier()]);
+        let output = cli.run(["--output=json", "get", "sources", source.identifier()]);
         serde_json::from_str::<Source>(&output).unwrap().into()
     };
 
@@ -244,7 +244,7 @@ fn test_create_source_with_transform_tag() {
     }
 
     let get_source_info = || -> SourceInfo {
-        let output = cli.run(&["--output=json", "get", "sources", source.identifier()]);
+        let output = cli.run(["--output=json", "get", "sources", source.identifier()]);
         serde_json::from_str::<Source>(&output).unwrap().into()
     };
 
@@ -263,7 +263,7 @@ fn test_create_source_with_invalid_transform_tag_fails() {
 
     let new_source_name = format!("{}/test-source-{}", owner, Uuid::new_v4());
 
-    let output = cli.run_and_error(&[
+    let output = cli.run_and_error([
         "create",
         "source",
         &new_source_name,
@@ -285,7 +285,7 @@ fn test_create_source_requires_owner() {
 
     let output = cli
         .command()
-        .args(&["create", "source", "source-without-owner"])
+        .args(["create", "source", "source-without-owner"])
         .output()
         .unwrap();
 


### PR DESCRIPTION
Does two things
 - Upgrade all dependencies by running `cargo upgrade` and `cargo update` -- except `indicatif` which was kept back as it needed more changes
 - Fixes clippy lints from rustc 1.65.0