### PR TITLE
comments: support fetching auto-thresholded labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 
+- `re get comments` will now return auto-thresholds for predicted labels if provided with a `--model-version` parameter
 - `re update users` for bulk user permission updates
 
 # v0.12.1

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -89,6 +89,11 @@ pub struct GetAnnotationsResponse {
     pub after: Option<GetLabellingsAfter>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetPredictionsResponse {
+    pub predictions: Vec<Prediction>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct UpdateAnnotationsRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -367,6 +372,15 @@ pub struct AnnotatedComment {
     pub moon_forms: Option<Vec<MoonForm>>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Prediction {
+    pub uid: Uid,
+    #[serde(skip_serializing_if = "should_skip_serializing_optional_vec")]
+    pub labels: Option<Vec<AutoThresholdLabel>>,
+    #[serde(skip_serializing_if = "should_skip_serializing_optional_vec")]
+    pub entities: Option<Vec<Entity>>,
+}
+
 pub fn get_default_labelling_group(labelling: &Option<Vec<Labelling>>) -> Option<&Labelling> {
     labelling
         .iter()
@@ -563,6 +577,15 @@ pub struct PredictedLabel {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sentiment: Option<NotNan<f64>>,
     pub probability: NotNan<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_thresholds: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AutoThresholdLabel {
+    pub name: Vec<String>,
+    pub probability: NotNan<f64>,
+    pub auto_thresholds: Vec<String>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -67,6 +67,9 @@ pub struct Id(pub String);
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct ModelFamily(pub String);
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+pub struct ModelVersion(pub u32);
+
 // TODO(mcobzarenco)[3963]: Make `Identifier` into a trait (ensure it still implements
 // `FromStr` so we can take T: Identifier as a clap command line argument).
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]

--- a/cli/src/commands/update/users.rs
+++ b/cli/src/commands/update/users.rs
@@ -30,7 +30,7 @@ pub fn update(client: &Client, args: &UpdateUsersArgs) -> Result<()> {
     let statistics = match &args.input_file {
         Some(input_file) => {
             info!("Processing users from file `{}`", input_file.display(),);
-            let file_metadata = fs::metadata(&input_file).with_context(|| {
+            let file_metadata = fs::metadata(input_file).with_context(|| {
                 format!("Could not get file metadata for `{}`", input_file.display())
             })?;
             let file = BufReader::new(


### PR DESCRIPTION
In order to be able to do an analysis like "X user property by label", I need to know a specific auto-threshold for each predicted label. The idea in this PR is that if a `--model-version` flag is provided to `re get comments --predictions true`, instead of fetching the latest predictions the CLI will fetch predictions from the specified model version with the corresponding auto-threshold information (using the [predict-comments](https://developers.reinfer.io/api/reference/predictions#get-predictions-for-a-pinned-model-by-comment-id) v1 route).

The output is not roundtrippable---I think that's fine? But happy to change if there are better ideas.