### PR TITLE
api: remove semantic-url-joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Removed semantic url joins to support deployments within a subdirectory
 
 ## Added
 

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -10,8 +10,8 @@ pub enum Error {
         message: String,
     },
 
-    #[error("Invalid endpoint `{}`", name)]
-    BadEndpoint { name: String },
+    #[error("Invalid endpoint: '{}'", endpoint)]
+    BadEndpoint { endpoint: url::Url },
 
     #[error("Bad token: {}", token)]
     BadToken { token: String },
@@ -70,9 +70,6 @@ pub enum Error {
         message: String,
         source: reqwest::Error,
     },
-
-    #[error("Url parsing error: {}", message)]
-    UrlParseError { message: String },
 
     #[error("An unknown error has occurred: {}", message)]
     Unknown {

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -72,10 +72,7 @@ pub enum Error {
     },
 
     #[error("Url parsing error: {}", message)]
-    UrlParseError {
-        message: String,
-        source: url::ParseError,
-    },
+    UrlParseError { message: String },
 
     #[error("An unknown error has occurred: {}", message)]
     Unknown {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1050,40 +1050,31 @@ struct Endpoints {
     projects: Url,
 }
 
-fn construct_endpoint(base: &Url, segments: Vec<&str>) -> Result<Url> {
-    let mut base = base.clone();
-    let original = base.clone();
+fn construct_endpoint(base: &Url, segments: &[&str]) -> Result<Url> {
+    let mut endpoint = base.clone();
 
-    let mut endpoint_segments = base.path_segments_mut().map_err(|_| Error::UrlParseError {
-        message: format!(
-            "Could not parse url with the base '{}' and segments '{}'",
-            original,
-            segments.join(", ")
-        ),
-    })?;
+    let mut endpoint_segments = endpoint
+        .path_segments_mut()
+        .map_err(|_| Error::BadEndpoint {
+            endpoint: base.clone(),
+        })?;
 
-    for segment in segments.into_iter() {
+    for segment in segments {
         endpoint_segments.push(segment);
     }
 
     drop(endpoint_segments);
-
-    Ok(base)
+    Ok(endpoint)
 }
 
 impl Endpoints {
     pub fn new(base: Url) -> Result<Self> {
-        let datasets = construct_endpoint(&base, vec!["api", "v1", "datasets"])?;
-
-        let sources = construct_endpoint(&base, vec!["api", "v1", "sources"])?;
-
-        let buckets = construct_endpoint(&base, vec!["api", "_private", "buckets"])?;
-
-        let users = construct_endpoint(&base, vec!["api", "_private", "users"])?;
-
-        let current_user = construct_endpoint(&base, vec!["auth", "user"])?;
-
-        let projects = construct_endpoint(&base, vec!["api", "_private", "projects"])?;
+        let datasets = construct_endpoint(&base, &["api", "v1", "datasets"])?;
+        let sources = construct_endpoint(&base, &["api", "v1", "sources"])?;
+        let buckets = construct_endpoint(&base, &["api", "_private", "buckets"])?;
+        let users = construct_endpoint(&base, &["api", "_private", "users"])?;
+        let current_user = construct_endpoint(&base, &["auth", "user"])?;
+        let projects = construct_endpoint(&base, &["api", "_private", "projects"])?;
 
         Ok(Endpoints {
             base,
@@ -1099,14 +1090,14 @@ impl Endpoints {
     fn triggers(&self, dataset_name: &DatasetFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "v1", "datasets", &dataset_name.0, "triggers"],
+            &["api", "v1", "datasets", &dataset_name.0, "triggers"],
         )
     }
 
     fn trigger_fetch(&self, trigger_name: &TriggerFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec![
+            &[
                 "api",
                 "v1",
                 "datasets",
@@ -1119,7 +1110,7 @@ impl Endpoints {
     fn trigger_advance(&self, trigger_name: &TriggerFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec![
+            &[
                 "api",
                 "v1",
                 "datasets",
@@ -1133,7 +1124,7 @@ impl Endpoints {
     fn trigger_reset(&self, trigger_name: &TriggerFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec![
+            &[
                 "api",
                 "v1",
                 "datasets",
@@ -1148,7 +1139,7 @@ impl Endpoints {
     fn trigger_exceptions(&self, trigger_name: &TriggerFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec![
+            &[
                 "api",
                 "v1",
                 "datasets",
@@ -1163,43 +1154,43 @@ impl Endpoints {
     fn recent_comments(&self, dataset_name: &DatasetFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "_private", "datasets", &dataset_name.0, "recent"],
+            &["api", "_private", "datasets", &dataset_name.0, "recent"],
         )
     }
 
     fn statistics(&self, dataset_name: &DatasetFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "_private", "datasets", &dataset_name.0, "statistics"],
+            &["api", "_private", "datasets", &dataset_name.0, "statistics"],
         )
     }
 
     fn user_by_id(&self, user_id: &UserId) -> Result<Url> {
-        construct_endpoint(&self.base, vec!["api", "_private", "users", &user_id.0])
+        construct_endpoint(&self.base, &["api", "_private", "users", &user_id.0])
     }
 
     fn source_by_id(&self, source_id: &SourceId) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "v1", "sources", &format!("id:{}", source_id.0)],
+            &["api", "v1", "sources", &format!("id:{}", source_id.0)],
         )
     }
 
     fn source_by_name(&self, source_name: &SourceFullName) -> Result<Url> {
-        construct_endpoint(&self.base, vec!["api", "v1", "sources", &source_name.0])
+        construct_endpoint(&self.base, &["api", "v1", "sources", &source_name.0])
     }
 
     fn comments(&self, source_name: &SourceFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "_private", "sources", &source_name.0, "comments"],
+            &["api", "_private", "sources", &source_name.0, "comments"],
         )
     }
 
     fn comment_by_id(&self, source_name: &SourceFullName, comment_id: &CommentId) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec![
+            &[
                 "api",
                 "v1",
                 "sources",
@@ -1213,21 +1204,21 @@ impl Endpoints {
     fn comments_v1(&self, source_name: &SourceFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "v1", "sources", &source_name.0, "comments"],
+            &["api", "v1", "sources", &source_name.0, "comments"],
         )
     }
 
     fn sync_comments(&self, source_name: &SourceFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "v1", "sources", &source_name.0, "sync"],
+            &["api", "v1", "sources", &source_name.0, "sync"],
         )
     }
 
     fn comment_audio(&self, source_id: &SourceId, comment_id: &CommentId) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec![
+            &[
                 "api",
                 "_private",
                 "sources",
@@ -1242,29 +1233,29 @@ impl Endpoints {
     fn put_emails(&self, bucket_name: &BucketFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "_private", "buckets", &bucket_name.0, "emails"],
+            &["api", "_private", "buckets", &bucket_name.0, "emails"],
         )
     }
 
     fn post_user(&self, user_id: &UserId) -> Result<Url> {
-        construct_endpoint(&self.base, vec!["api", "_private", "users", &user_id.0])
+        construct_endpoint(&self.base, &["api", "_private", "users", &user_id.0])
     }
 
     fn dataset_by_id(&self, dataset_id: &DatasetId) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "v1", "datasets", &format!("id:{}", dataset_id.0)],
+            &["api", "v1", "datasets", &format!("id:{}", dataset_id.0)],
         )
     }
 
     fn dataset_by_name(&self, dataset_name: &DatasetFullName) -> Result<Url> {
-        construct_endpoint(&self.base, vec!["api", "v1", "datasets", &dataset_name.0])
+        construct_endpoint(&self.base, &["api", "v1", "datasets", &dataset_name.0])
     }
 
     fn get_labellings(&self, dataset_name: &DatasetFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "_private", "datasets", &dataset_name.0, "labellings"],
+            &["api", "_private", "datasets", &dataset_name.0, "labellings"],
         )
     }
 
@@ -1275,7 +1266,7 @@ impl Endpoints {
     ) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec![
+            &[
                 "api",
                 "v1",
                 "datasets",
@@ -1294,7 +1285,7 @@ impl Endpoints {
     ) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec![
+            &[
                 "api",
                 "_private",
                 "datasets",
@@ -1308,21 +1299,18 @@ impl Endpoints {
     fn bucket_by_id(&self, bucket_id: &BucketId) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "_private", "buckets", &format!("id:{}", bucket_id.0)],
+            &["api", "_private", "buckets", &format!("id:{}", bucket_id.0)],
         )
     }
 
     fn bucket_by_name(&self, bucket_name: &BucketFullName) -> Result<Url> {
-        construct_endpoint(
-            &self.base,
-            vec!["api", "_private", "buckets", &bucket_name.0],
-        )
+        construct_endpoint(&self.base, &["api", "_private", "buckets", &bucket_name.0])
     }
 
     fn project_by_name(&self, project_name: &ProjectName) -> Result<Url> {
         construct_endpoint(
             &self.base,
-            vec!["api", "_private", "projects", &project_name.0],
+            &["api", "_private", "projects", &project_name.0],
         )
     }
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1050,44 +1050,41 @@ struct Endpoints {
     projects: Url,
 }
 
+fn construct_endpoint(base: &Url, segments: Vec<&str>) -> Result<Url> {
+    let mut base = base.clone();
+    let original = base.clone();
+
+    let mut endpoint_segments = base.path_segments_mut().map_err(|_| Error::UrlParseError {
+        message: format!(
+            "Could not parse url with the base '{}' and segments '{}'",
+            original,
+            segments.join(", ")
+        ),
+    })?;
+
+    for segment in segments.into_iter() {
+        endpoint_segments.push(segment);
+    }
+
+    drop(endpoint_segments);
+
+    Ok(base)
+}
+
 impl Endpoints {
     pub fn new(base: Url) -> Result<Self> {
-        let datasets = base
-            .join("/api/v1/datasets")
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL for dataset resources.".to_owned(),
-            })?;
-        let sources = base
-            .join("/api/v1/sources")
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL for source resources.".to_owned(),
-            })?;
-        let buckets =
-            base.join("/api/_private/buckets")
-                .map_err(|source| Error::UrlParseError {
-                    source,
-                    message: "Could not build URL for bucket resources.".to_owned(),
-                })?;
-        let users = base
-            .join("/api/_private/users")
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL for users resources.".to_owned(),
-            })?;
-        let current_user = base
-            .join("/auth/user")
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL for users resources.".to_owned(),
-            })?;
-        let projects =
-            base.join("/api/_private/projects")
-                .map_err(|source| Error::UrlParseError {
-                    source,
-                    message: "Could not build URL for project resources.".to_owned(),
-                })?;
+        let datasets = construct_endpoint(&base, vec!["api", "v1", "datasets"])?;
+
+        let sources = construct_endpoint(&base, vec!["api", "v1", "sources"])?;
+
+        let buckets = construct_endpoint(&base, vec!["api", "_private", "buckets"])?;
+
+        let users = construct_endpoint(&base, vec!["api", "_private", "users"])?;
+
+        let current_user = construct_endpoint(&base, vec!["auth", "user"])?;
+
+        let projects = construct_endpoint(&base, vec!["api", "_private", "projects"])?;
+
         Ok(Endpoints {
             base,
             datasets,
@@ -1100,240 +1097,175 @@ impl Endpoints {
     }
 
     fn triggers(&self, dataset_name: &DatasetFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/v1/datasets/{}/triggers", dataset_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL to get trigger resources.".to_owned(),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "v1", "datasets", &dataset_name.0, "triggers"],
+        )
     }
 
     fn trigger_fetch(&self, trigger_name: &TriggerFullName) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/v1/datasets/{}/triggers/{}/fetch",
-                trigger_name.dataset.0, trigger_name.trigger.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL to fetch trigger results.".to_owned(),
-            })
+        construct_endpoint(
+            &self.base,
+            vec![
+                "api",
+                "v1",
+                "datasets",
+                &trigger_name.dataset.0,
+                &trigger_name.trigger.0,
+            ],
+        )
     }
 
     fn trigger_advance(&self, trigger_name: &TriggerFullName) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/v1/datasets/{}/triggers/{}/advance",
-                trigger_name.dataset.0, trigger_name.trigger.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL to advance triggers.".to_owned(),
-            })
+        construct_endpoint(
+            &self.base,
+            vec![
+                "api",
+                "v1",
+                "datasets",
+                &trigger_name.dataset.0,
+                "triggers",
+                &trigger_name.trigger.0,
+            ],
+        )
     }
 
     fn trigger_reset(&self, trigger_name: &TriggerFullName) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/v1/datasets/{}/triggers/{}/reset",
-                trigger_name.dataset.0, trigger_name.trigger.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL to reset triggers.".to_owned(),
-            })
+        construct_endpoint(
+            &self.base,
+            vec![
+                "api",
+                "v1",
+                "datasets",
+                &trigger_name.dataset.0,
+                "triggers",
+                &trigger_name.trigger.0,
+                "reset",
+            ],
+        )
     }
 
     fn trigger_exceptions(&self, trigger_name: &TriggerFullName) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/v1/datasets/{}/triggers/{}/exceptions",
-                trigger_name.dataset.0, trigger_name.trigger.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL for trigger exceptions.".to_owned(),
-            })
+        construct_endpoint(
+            &self.base,
+            vec![
+                "api",
+                "v1",
+                "datasets",
+                &trigger_name.dataset.0,
+                "triggers",
+                &trigger_name.trigger.0,
+                "exceptions",
+            ],
+        )
     }
 
     fn recent_comments(&self, dataset_name: &DatasetFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/_private/datasets/{}/recent", dataset_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL for recent comments query.".to_owned(),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "_private", "datasets", &dataset_name.0, "recent"],
+        )
     }
 
     fn statistics(&self, dataset_name: &DatasetFullName) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/_private/datasets/{}/statistics",
-                dataset_name.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: "Could not build URL for dataset statistics query.".to_owned(),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "_private", "datasets", &dataset_name.0, "statistics"],
+        )
     }
 
     fn user_by_id(&self, user_id: &UserId) -> Result<Url> {
-        self.base
-            .join(&format!("/api/_private/users/{}", user_id.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build URL for source resource with id `{}`.",
-                    user_id.0
-                ),
-            })
+        construct_endpoint(&self.base, vec!["api", "_private", "users", &user_id.0])
     }
 
     fn source_by_id(&self, source_id: &SourceId) -> Result<Url> {
-        self.base
-            .join(&format!("/api/v1/sources/id:{}", source_id.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build URL for source resource with id `{}`.",
-                    source_id.0
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "v1", "sources", &format!("id:{}", source_id.0)],
+        )
     }
 
     fn source_by_name(&self, source_name: &SourceFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/v1/sources/{}", source_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build URL for source resource with name `{}`.",
-                    source_name.0
-                ),
-            })
+        construct_endpoint(&self.base, vec!["api", "v1", "sources", &source_name.0])
     }
 
     fn comments(&self, source_name: &SourceFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/_private/sources/{}/comments", source_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build get comments URL for source `{}`.",
-                    source_name.0,
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "_private", "sources", &source_name.0, "comments"],
+        )
     }
 
     fn comment_by_id(&self, source_name: &SourceFullName, comment_id: &CommentId) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/v1/sources/{}/comments/{}",
-                source_name.0, comment_id.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build get comment by id URL for source `{}`, comment `{}`.",
-                    source_name.0, comment_id.0,
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec![
+                "api",
+                "v1",
+                "sources",
+                &source_name.0,
+                "comments",
+                &comment_id.0,
+            ],
+        )
     }
 
     fn comments_v1(&self, source_name: &SourceFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/v1/sources/{}/comments", source_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build get comments v1 URL for source `{}`.",
-                    source_name.0,
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "v1", "sources", &source_name.0, "comments"],
+        )
     }
 
     fn sync_comments(&self, source_name: &SourceFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/v1/sources/{}/sync", source_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!("Could not build sync URL for source `{}`.", source_name.0),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "v1", "sources", &source_name.0, "sync"],
+        )
     }
 
     fn comment_audio(&self, source_id: &SourceId, comment_id: &CommentId) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/_private/sources/id:{}/comments/{}/audio",
-                source_id.0, comment_id.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                message: format!(
-                    "Could not build audio content URL for source id `{}` and comment id `{}`.",
-                    source_id.0, comment_id.0,
-                ),
-                source,
-            })
+        construct_endpoint(
+            &self.base,
+            vec![
+                "api",
+                "_private",
+                "sources",
+                &format!("id:{}", source_id.0),
+                "comments",
+                &comment_id.0,
+                "audio",
+            ],
+        )
     }
 
     fn put_emails(&self, bucket_name: &BucketFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/_private/buckets/{}/emails", bucket_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build put emails URL for bucket `{}`.",
-                    bucket_name,
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "_private", "buckets", &bucket_name.0, "emails"],
+        )
     }
 
     fn post_user(&self, user_id: &UserId) -> Result<Url> {
-        self.base
-            .join(&format!("/api/_private/users/{}", user_id.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!("Could not build post user URL for user `{}`.", user_id.0,),
-            })
+        construct_endpoint(&self.base, vec!["api", "_private", "users", &user_id.0])
     }
 
     fn dataset_by_id(&self, dataset_id: &DatasetId) -> Result<Url> {
-        self.base
-            .join(&format!("/api/v1/datasets/id:{}", dataset_id.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build URL for dataset resource with id `{}`.",
-                    dataset_id.0
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "v1", "datasets", &format!("id:{}", dataset_id.0)],
+        )
     }
 
     fn dataset_by_name(&self, dataset_name: &DatasetFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/v1/datasets/{}", dataset_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build URL for dataset resource with name `{}`.",
-                    dataset_name.0
-                ),
-            })
+        construct_endpoint(&self.base, vec!["api", "v1", "datasets", &dataset_name.0])
     }
 
     fn get_labellings(&self, dataset_name: &DatasetFullName) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/_private/datasets/{}/labellings",
-                dataset_name.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build get labellings URL for dataset `{}`.",
-                    dataset_name.0,
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "_private", "datasets", &dataset_name.0, "labellings"],
+        )
     }
 
     fn get_comment_predictions(
@@ -1341,18 +1273,18 @@ impl Endpoints {
         dataset_name: &DatasetFullName,
         model_version: &ModelVersion,
     ) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/v1/datasets/{}/labellers/{}/predict-comments",
-                dataset_name.0, model_version.0
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build get predictions URL for dataset `{}` and model version `{}`.",
-                    dataset_name.0, model_version.0
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec![
+                "api",
+                "v1",
+                "datasets",
+                &dataset_name.0,
+                "labellers",
+                &model_version.0.to_string(),
+                "predict-comments",
+            ],
+        )
     }
 
     fn post_labelling(
@@ -1360,54 +1292,38 @@ impl Endpoints {
         dataset_name: &DatasetFullName,
         comment_uid: &CommentUid,
     ) -> Result<Url> {
-        self.base
-            .join(&format!(
-                "/api/_private/datasets/{}/labellings/{}",
-                dataset_name.0, comment_uid.0,
-            ))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build get labellings URL for dataset `{}`.",
-                    dataset_name.0,
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec![
+                "api",
+                "_private",
+                "datasets",
+                &dataset_name.0,
+                "labellings",
+                &comment_uid.0,
+            ],
+        )
     }
 
     fn bucket_by_id(&self, bucket_id: &BucketId) -> Result<Url> {
-        self.base
-            .join(&format!("/api/_private/buckets/id:{}", bucket_id.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build URL for bucket resource with id `{}`.",
-                    bucket_id.0
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "_private", "buckets", &format!("id:{}", bucket_id.0)],
+        )
     }
 
     fn bucket_by_name(&self, bucket_name: &BucketFullName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/_private/buckets/{}", bucket_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build URL for bucket resource with name `{}`.",
-                    bucket_name.0
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "_private", "buckets", &bucket_name.0],
+        )
     }
 
     fn project_by_name(&self, project_name: &ProjectName) -> Result<Url> {
-        self.base
-            .join(&format!("/api/_private/projects/{}", project_name.0))
-            .map_err(|source| Error::UrlParseError {
-                source,
-                message: format!(
-                    "Could not build URL for project resource with name `{}`.",
-                    project_name.0
-                ),
-            })
+        construct_endpoint(
+            &self.base,
+            vec!["api", "_private", "projects", &project_name.0],
+        )
     }
 }
 


### PR DESCRIPTION
The `join` function only joins to the base of a given `url`, this is incompatible with deployments which live in sub directories. This PR seeks to address that.