### PR TITLE
args: Make the -k arg be a plain bool

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -36,8 +36,8 @@ pub struct Args {
     /// context, if any.
     pub endpoint: Option<Url>,
 
-    #[structopt(short = "k", long = "accept-invalid-certificates", parse(try_from_str))]
-    pub accept_invalid_certificates: Option<bool>,
+    #[structopt(short = "k", long = "accept-invalid-certificates")]
+    pub accept_invalid_certificates: bool,
 
     #[structopt(long = "token")]
     /// Specify what API token to use. Overrides the one from the current

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,10 +83,10 @@ fn client_from_args(args: &Args, config: &ReinferConfig) -> Result<Client> {
         utils::read_token_from_stdin()?.unwrap_or_default()
     });
 
-    let accept_invalid_certificates = args
-        .accept_invalid_certificates
-        .or_else(|| current_context.map(|context| context.accept_invalid_certificates))
-        .unwrap_or(false);
+    let accept_invalid_certificates = args.accept_invalid_certificates
+        || current_context
+            .map(|context| context.accept_invalid_certificates)
+            .unwrap_or(false);
 
     if accept_invalid_certificates {
         warn!(concat!(


### PR DESCRIPTION
This emulates the same -k format used in curl, where the flag doesn't take any parameter, it simpy gets activated if the -k is passed.


I found this when following the platform README, to try the public API, it was confusing that i needed to do `-k true`. Hope this doesn't break anyone's scripts?