### PR TITLE
Add `create quota` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+# Unreleased
+
+## Added
+
+- `re create quota` to set a quota in a tenant
+
 # v0.12.2
+
 - Rename "triggers" to "streams" following the rename in the API
 - Removed semantic url joins to support deployments within a subdirectory
 - Added functionality to use moon forms both in `LabelDef`s and in `AnnotatedComments`s

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1233,7 @@ version = "0.12.2"
 dependencies = [
  "chrono",
  "log",
+ "matches",
  "mockito",
  "once_cell",
  "ordered-float",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,6 +14,7 @@ name = "reinfer_client"
 [dependencies]
 chrono = { version = "0.4.22", features = ["serde"] }
 log = "0.4.17"
+matches = "0.1.10"
 once_cell = "1.16.0"
 ordered-float = { version = "3.3.0", features = ["serde"] }
 regex = "1.6.0"

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -49,6 +49,9 @@ pub enum Error {
     #[error("Expected a valid bucket type, got: {}", bucket_type)]
     BadBucketType { bucket_type: String },
 
+    #[error("Expected a valid quota kind, got: {}", tenant_quota_kind)]
+    BadTenantQuotaKind { tenant_quota_kind: String },
+
     #[error("Could not parse JSON response.")]
     BadJsonResponse(#[source] reqwest::Error),
 

--- a/api/src/resources/mod.rs
+++ b/api/src/resources/mod.rs
@@ -6,9 +6,11 @@ pub mod entity_def;
 pub mod label_def;
 pub mod label_group;
 pub mod project;
+pub mod quota;
 pub mod source;
 pub mod statistics;
 pub mod stream;
+pub mod tenant_id;
 pub mod user;
 
 use crate::error::{Error, Result};

--- a/api/src/resources/quota.rs
+++ b/api/src/resources/quota.rs
@@ -1,0 +1,128 @@
+use crate::error::{Error, Result};
+use serde::Serialize;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+use std::{fmt::Display, str::FromStr};
+
+#[derive(Debug, Clone, SerializeDisplay, DeserializeFromStr, PartialEq, Eq, Hash, Copy)]
+pub enum TenantQuotaKind {
+    Sources,
+    SourcesPerDataset,
+    Datasets,
+    DatasetsPerSource,
+    LabelsPerDataset,
+    EntitiesPerDataset,
+    Comments,
+    CommentsPerSource,
+    ReviewedCommentsPerDataset,
+    Integrations,
+    MailboxesPerIntegration,
+    Triggers,
+    TriggersPerDataset,
+    Users,
+    Alerts,
+    Buckets,
+    Projects,
+    PinnedModels,
+}
+
+impl FromStr for TenantQuotaKind {
+    type Err = Error;
+
+    fn from_str(string: &str) -> Result<Self> {
+        let tenant_quota_kind = match string {
+            "sources" => TenantQuotaKind::Sources,
+            "sources_per_dataset" => TenantQuotaKind::SourcesPerDataset,
+            "datasets" => TenantQuotaKind::Datasets,
+            "datasets_per_source" => TenantQuotaKind::DatasetsPerSource,
+            "labels_per_dataset" => TenantQuotaKind::LabelsPerDataset,
+            "entities_per_dataset" => TenantQuotaKind::EntitiesPerDataset,
+            "comments" => TenantQuotaKind::Comments,
+            "comments_per_source" => TenantQuotaKind::CommentsPerSource,
+            "reviewed_comments_per_dataset" => TenantQuotaKind::ReviewedCommentsPerDataset,
+            "integrations" => TenantQuotaKind::Integrations,
+            "mailboxes_per_integration" => TenantQuotaKind::MailboxesPerIntegration,
+            "triggers" => TenantQuotaKind::Triggers,
+            "triggers_per_dataset" => TenantQuotaKind::TriggersPerDataset,
+            "users" => TenantQuotaKind::Users,
+            "alerts" => TenantQuotaKind::Alerts,
+            "buckets" => TenantQuotaKind::Buckets,
+            "projects" => TenantQuotaKind::Projects,
+            "pinned_models" => TenantQuotaKind::PinnedModels,
+            _ => {
+                return Err(Error::BadTenantQuotaKind {
+                    tenant_quota_kind: string.to_string(),
+                })
+            }
+        };
+        Ok(tenant_quota_kind)
+    }
+}
+
+impl Display for TenantQuotaKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                TenantQuotaKind::Sources => "sources",
+                TenantQuotaKind::SourcesPerDataset => "sources_per_dataset",
+                TenantQuotaKind::Datasets => "datasets",
+                TenantQuotaKind::DatasetsPerSource => "datasets_per_source",
+                TenantQuotaKind::LabelsPerDataset => "labels_per_dataset",
+                TenantQuotaKind::EntitiesPerDataset => "entities_per_dataset",
+                TenantQuotaKind::Comments => "comments",
+                TenantQuotaKind::CommentsPerSource => "comments_per_source",
+                TenantQuotaKind::ReviewedCommentsPerDataset => "reviewed_comments_per_dataset",
+                TenantQuotaKind::Integrations => "integrations",
+                TenantQuotaKind::MailboxesPerIntegration => "mailboxes_per_integration",
+                TenantQuotaKind::Triggers => "triggers",
+                TenantQuotaKind::TriggersPerDataset => "triggers_per_dataset",
+                TenantQuotaKind::Users => "users",
+                TenantQuotaKind::Alerts => "alerts",
+                TenantQuotaKind::Buckets => "buckets",
+                TenantQuotaKind::Projects => "projects",
+                TenantQuotaKind::PinnedModels => "pinned_models",
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, Default)]
+pub struct CreateQuota {
+    pub hard_limit: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use matches::assert_matches;
+
+    #[test]
+    fn tenant_quota_kind_roundtrips() {
+        assert_eq!(
+            TenantQuotaKind::Sources,
+            TenantQuotaKind::from_str("sources").unwrap()
+        );
+        assert_eq!(
+            &serde_json::ser::to_string(&TenantQuotaKind::Sources).unwrap(),
+            "\"sources\""
+        );
+
+        assert_eq!(
+            TenantQuotaKind::SourcesPerDataset,
+            TenantQuotaKind::from_str("sources_per_dataset").unwrap()
+        );
+        assert_eq!(
+            &serde_json::ser::to_string(&TenantQuotaKind::SourcesPerDataset).unwrap(),
+            "\"sources_per_dataset\""
+        );
+    }
+
+    #[test]
+    fn deserialising_unknown_tenant_quota_kind_fails() {
+        assert_matches!(
+            TenantQuotaKind::from_str("unknown"),
+            Err(Error::BadTenantQuotaKind { .. })
+        );
+    }
+}

--- a/api/src/resources/tenant_id.rs
+++ b/api/src/resources/tenant_id.rs
@@ -1,0 +1,43 @@
+use crate::{Error, Result};
+use std::{fmt::Display, str::FromStr};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReinferTenantId(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UiPathTenantId(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TenantId {
+    Reinfer(ReinferTenantId),
+    UiPath(UiPathTenantId),
+}
+
+impl Display for TenantId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                TenantId::Reinfer(ReinferTenantId(tenant_id))
+                | TenantId::UiPath(UiPathTenantId(tenant_id)) => tenant_id,
+            }
+        )
+    }
+}
+
+impl FromStr for ReinferTenantId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl FromStr for UiPathTenantId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(Self(s.to_string()))
+    }
+}

--- a/cli/src/commands/create/mod.rs
+++ b/cli/src/commands/create/mod.rs
@@ -4,6 +4,7 @@ mod comments;
 mod dataset;
 mod emails;
 mod project;
+mod quota;
 mod source;
 mod stream_exception;
 mod user;
@@ -11,7 +12,8 @@ mod user;
 use self::{
     annotations::CreateAnnotationsArgs, bucket::CreateBucketArgs, comments::CreateCommentsArgs,
     dataset::CreateDatasetArgs, emails::CreateEmailsArgs, project::CreateProjectArgs,
-    source::CreateSourceArgs, stream_exception::CreateStreamExceptionArgs, user::CreateUserArgs,
+    quota::CreateQuotaArgs, source::CreateSourceArgs, stream_exception::CreateStreamExceptionArgs,
+    user::CreateUserArgs,
 };
 use crate::printer::Printer;
 use anyhow::Result;
@@ -55,6 +57,10 @@ pub enum CreateArgs {
     #[structopt(name = "stream-exception")]
     /// Create a new stream exception
     StreamException(CreateStreamExceptionArgs),
+
+    #[structopt(name = "quota")]
+    /// Set a new value for a quota
+    Quota(CreateQuotaArgs),
 }
 
 pub fn run(create_args: &CreateArgs, client: Client, printer: &Printer) -> Result<()> {
@@ -70,5 +76,6 @@ pub fn run(create_args: &CreateArgs, client: Client, printer: &Printer) -> Resul
         CreateArgs::StreamException(stream_exception_args) => {
             stream_exception::create(&client, stream_exception_args, printer)
         }
+        CreateArgs::Quota(quota_args) => quota::create(&client, quota_args),
     }
 }

--- a/cli/src/commands/create/quota.rs
+++ b/cli/src/commands/create/quota.rs
@@ -1,0 +1,65 @@
+use anyhow::{anyhow, Context, Result};
+use log::info;
+use reinfer_client::{
+    resources::{
+        quota::{CreateQuota, TenantQuotaKind},
+        tenant_id::{ReinferTenantId, TenantId, UiPathTenantId},
+    },
+    Client,
+};
+use structopt::{clap::ArgGroup, StructOpt};
+
+#[derive(Debug, StructOpt)]
+#[structopt(group = ArgGroup::with_name("tenant-id").required(true))]
+pub struct CreateQuotaArgs {
+    #[structopt(long = "reinfer-tenant-id", group = "tenant-id")]
+    /// Reinfer tenant ID for which to set the quota
+    reinfer_tenant_id: Option<ReinferTenantId>,
+
+    #[structopt(long = "uipath-tenant-id", group = "tenant-id")]
+    /// UiPath tenant ID for which to set the quota
+    uipath_tenant_id: Option<UiPathTenantId>,
+
+    #[structopt(long = "quota-kind")]
+    /// Kind of quota to set
+    tenant_quota_kind: TenantQuotaKind,
+
+    #[structopt(long = "limit")]
+    /// New value of the quota to set
+    hard_limit: u32,
+}
+
+pub fn create(client: &Client, args: &CreateQuotaArgs) -> Result<()> {
+    let CreateQuotaArgs {
+        reinfer_tenant_id,
+        uipath_tenant_id,
+        tenant_quota_kind,
+        hard_limit,
+    } = args;
+
+    let tenant_id: TenantId = match (reinfer_tenant_id, uipath_tenant_id) {
+        (Some(tenant_id), None) => TenantId::Reinfer(tenant_id.to_owned()),
+        (None, Some(tenant_id)) => TenantId::UiPath(tenant_id.to_owned()),
+        _ => {
+            return Err(anyhow!(
+                "Expected one and only one tenant ID, got none or two."
+            ))
+        }
+    };
+
+    client
+        .create_quota(
+            &tenant_id,
+            *tenant_quota_kind,
+            CreateQuota {
+                hard_limit: *hard_limit,
+            },
+        )
+        .context("Operation to set quota has failed")?;
+
+    info!(
+        "New quota `{}` set successfully in tenant with id `{}`",
+        tenant_quota_kind, tenant_id
+    );
+    Ok(())
+}


### PR DESCRIPTION
Add a new `create quota` command, to allow support users to set values for quotas for specific resources.

Example usage:
```bash
re create quota --reinfer-tenant-id abcdefabcdefabcd --quota-kind labels_per_dataset --limit 50
```