### PR TITLE
api: add time series and by label filters to statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Added
 
 - Add `no-charge` flag to create comment/email commands
+- Add comment and label filters to `get_statistics`
+- Add timeseries to `get_statistics`
 
 
 ## Added

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -12,7 +12,7 @@ use reqwest::{
     header::{self, HeaderMap, HeaderValue},
     IntoUrl, Proxy, Result as ReqwestResult,
 };
-use resources::project::ForceDeleteProject;
+use resources::{dataset::StatisticsRequestParams, project::ForceDeleteProject};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{cell::Cell, fmt::Display, path::Path};
@@ -610,11 +610,15 @@ impl Client {
         Ok(())
     }
 
-    pub fn get_statistics(&self, dataset_name: &DatasetFullName) -> Result<Statistics> {
+    pub fn get_statistics(
+        &self,
+        dataset_name: &DatasetFullName,
+        params: &StatisticsRequestParams,
+    ) -> Result<Statistics> {
         Ok(self
             .post::<_, _, GetStatisticsResponse>(
                 self.endpoints.statistics(dataset_name)?,
-                json!({}),
+                json!(params),
                 Retry::No,
             )?
             .statistics)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -618,7 +618,7 @@ impl Client {
         Ok(self
             .post::<_, _, GetStatisticsResponse>(
                 self.endpoints.statistics(dataset_name)?,
-                json!(params),
+                serde_json::to_value(params).expect("statistics params serialization error"),
                 Retry::No,
             )?
             .statistics)

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -12,7 +12,7 @@ use serde::{
     ser::{SerializeMap, Serializer},
     Deserialize, Serialize,
 };
-use serde_json::{json, Value as JsonValue};
+use serde_json::Value as JsonValue;
 use std::{
     collections::HashMap,
     fmt::{Formatter, Result as FmtResult},
@@ -47,19 +47,16 @@ impl FromStr for Uid {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct ThreadId(pub String);
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-pub struct CommentFilter(pub JsonValue);
-
-impl Default for CommentFilter {
-    fn default() -> Self {
-        Self::empty()
-    }
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommentTimestampFilter {
+    pub minimum: DateTime<Utc>,
+    pub maximum: DateTime<Utc>,
 }
 
-impl CommentFilter {
-    pub fn empty() -> Self {
-        CommentFilter(json!({}))
-    }
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommentFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<CommentTimestampFilter>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -234,7 +234,6 @@ mod tests {
 
     use super::*;
     use chrono::TimeZone;
-    use serde_json::json;
 
     #[test]
     pub fn test_serialize_statistics_request_params_default() {
@@ -270,8 +269,8 @@ mod tests {
         };
 
         assert_eq!(
-            json!(params).to_string(),
-            r#"{"attribute_filters":[{"attribute":"labels","filter":{"any_of":["label Name"],"kind":"string_any_of"}}],"comment_filter":{"timestamp":{"maximum":"2020-03-17T13:33:15Z","minimum":"2019-03-17T16:43:00Z"}},"label_property_timeseries":true,"label_timeseries":true,"time_resolution":"day"}"#
+            serde_json::to_string(&params).unwrap(),
+            r#"{"attribute_filters":[{"attribute":"labels","filter":{"kind":"string_any_of","any_of":["label Name"]}}],"comment_filter":{"timestamp":{"minimum":"2019-03-17T16:43:00Z","maximum":"2020-03-17T13:33:15Z"}},"label_property_timeseries":true,"label_timeseries":true,"time_resolution":"day"}"#
         )
     }
 }

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -90,17 +90,17 @@ pub struct AttributeFilter {
 
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct StatisticsRequestParams {
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    pub attribute_filters: Vec<AttributeFilter>,
+
+    pub comment_filter: CommentFilter,
+
     pub label_property_timeseries: bool,
 
     pub label_timeseries: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_resolution: Option<TimeResolution>,
-
-    #[serde(skip_serializing_if = "<[_]>::is_empty")]
-    pub attribute_filters: Vec<AttributeFilter>,
-
-    pub comment_filter: CommentFilter,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
@@ -238,12 +238,9 @@ mod tests {
 
     #[test]
     pub fn test_serialize_statistics_request_params_default() {
-        let params = StatisticsRequestParams {
-            ..Default::default()
-        };
-
+        let params = StatisticsRequestParams::default();
         assert_eq!(
-            json!(params).to_string(),
+            serde_json::to_string(&params).unwrap(),
             "{\"comment_filter\":{},\"label_property_timeseries\":false,\"label_timeseries\":false}"
         )
     }

--- a/api/src/resources/statistics.rs
+++ b/api/src/resources/statistics.rs
@@ -1,12 +1,35 @@
+use std::collections::HashMap;
+
+use crate::LabelName;
+use chrono::NaiveDate;
 use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub(crate) struct GetResponse {
     pub statistics: Statistics,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct LabelCount {
+    positive: f32,
+    negative: f32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum TimeSeriesEntry {
+    Timestamp(NaiveDate),
+    Number(f32),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Statistics {
     pub num_comments: NotNan<f64>,
+
+    #[serde(default)]
+    pub label_counts: HashMap<LabelName, LabelCount>,
+
+    #[serde(default)]
+    pub label_timeseries: Vec<Vec<TimeSeriesEntry>>,
 }

--- a/cli/src/commands/get/comments.rs
+++ b/cli/src/commands/get/comments.rs
@@ -2,9 +2,9 @@ use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use reinfer_client::{
-    resources::dataset::StatisticsRequestParams, AnnotatedComment, Client, CommentId,
-    CommentsIterTimerange, DatasetFullName, DatasetIdentifier, Entities, HasAnnotations, LabelName,
-    Labelling, ModelVersion, PredictedLabel, Source, SourceIdentifier, DEFAULT_LABEL_GROUP_NAME,
+    AnnotatedComment, Client, CommentId, CommentsIterTimerange, DatasetFullName, DatasetIdentifier,
+    Entities, HasAnnotations, LabelName, Labelling, ModelVersion, PredictedLabel, Source,
+    SourceIdentifier, DEFAULT_LABEL_GROUP_NAME,
 };
 use std::{
     fs::File,
@@ -198,12 +198,7 @@ fn download_comments(
         Ok(get_comments_progress_bar(
             if let Some(dataset_name) = dataset_name {
                 *client
-                    .get_statistics(
-                        dataset_name,
-                        &StatisticsRequestParams {
-                            ..Default::default()
-                        },
-                    )
+                    .get_statistics(dataset_name, &Default::default())
                     .context("Operation to get comment count has failed..")?
                     .num_comments as u64
             } else {

--- a/cli/src/commands/get/comments.rs
+++ b/cli/src/commands/get/comments.rs
@@ -2,9 +2,9 @@ use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use reinfer_client::{
-    AnnotatedComment, Client, CommentId, CommentsIterTimerange, DatasetFullName, DatasetIdentifier,
-    Entities, HasAnnotations, LabelName, Labelling, ModelVersion, PredictedLabel, Source,
-    SourceIdentifier, DEFAULT_LABEL_GROUP_NAME,
+    resources::dataset::StatisticsRequestParams, AnnotatedComment, Client, CommentId,
+    CommentsIterTimerange, DatasetFullName, DatasetIdentifier, Entities, HasAnnotations, LabelName,
+    Labelling, ModelVersion, PredictedLabel, Source, SourceIdentifier, DEFAULT_LABEL_GROUP_NAME,
 };
 use std::{
     fs::File,
@@ -198,7 +198,12 @@ fn download_comments(
         Ok(get_comments_progress_bar(
             if let Some(dataset_name) = dataset_name {
                 *client
-                    .get_statistics(dataset_name)
+                    .get_statistics(
+                        dataset_name,
+                        &StatisticsRequestParams {
+                            ..Default::default()
+                        },
+                    )
                     .context("Operation to get comment count has failed..")?
                     .num_comments as u64
             } else {


### PR DESCRIPTION
Expands the scope of queries that can be made to the statistics endpoint. Needed for an internal project.