### PR TITLE
api: add query endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `no-charge` flag to create comment/email commands
 - Add comment and label filters to `get_statistics`
 - Add timeseries to `get_statistics`
+- Add `query_dataset` to api
 
 
 ## Added

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -12,7 +12,10 @@ use reqwest::{
     header::{self, HeaderMap, HeaderValue},
     IntoUrl, Proxy, Result as ReqwestResult,
 };
-use resources::{dataset::StatisticsRequestParams, project::ForceDeleteProject};
+use resources::{
+    dataset::{QueryRequestParams, QueryResponse, StatisticsRequestParams},
+    project::ForceDeleteProject,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{cell::Cell, fmt::Display, path::Path};
@@ -601,6 +604,18 @@ impl Client {
             .user)
     }
 
+    pub fn query_dataset(
+        &self,
+        dataset_name: &DatasetFullName,
+        params: &QueryRequestParams,
+    ) -> Result<QueryResponse> {
+        Ok(self.post::<_, _, QueryResponse>(
+            self.endpoints.query_dataset(dataset_name)?,
+            serde_json::to_value(params).expect("query params serialization error"),
+            Retry::Yes,
+        )?)
+    }
+
     pub fn send_welcome_email(&self, user_id: UserId) -> Result<()> {
         self.post::<_, _, WelcomeEmailResponse>(
             self.endpoints.welcome_email(&user_id)?,
@@ -1122,6 +1137,13 @@ impl Endpoints {
             current_user,
             projects,
         })
+    }
+
+    fn query_dataset(&self, dataset_name: &DatasetFullName) -> Result<Url> {
+        construct_endpoint(
+            &self.base,
+            &["api", "_private", "datasets", &dataset_name.0, "query"],
+        )
     }
 
     fn streams(&self, dataset_name: &DatasetFullName) -> Result<Url> {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -609,11 +609,11 @@ impl Client {
         dataset_name: &DatasetFullName,
         params: &QueryRequestParams,
     ) -> Result<QueryResponse> {
-        Ok(self.post::<_, _, QueryResponse>(
+        self.post::<_, _, QueryResponse>(
             self.endpoints.query_dataset(dataset_name)?,
             serde_json::to_value(params).expect("query params serialization error"),
             Retry::Yes,
-        )?)
+        )
     }
 
     pub fn send_welcome_email(&self, user_id: UserId) -> Result<()> {
@@ -936,7 +936,7 @@ impl Client {
         };
         let http_response = result.map_err(|source| Error::ReqwestError {
             source,
-            message: format!("{} operation failed.", method),
+            message: format!("{method} operation failed."),
         })?;
 
         let status = http_response.status();

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -49,12 +49,25 @@ pub struct ThreadId(pub String);
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CommentTimestampFilter {
-    pub minimum: DateTime<Utc>,
-    pub maximum: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<DateTime<Utc>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewedFilterEnum {
+    OnlyReviewed,
+    OnlyUnreviewed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CommentFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reviewed: Option<ReviewedFilterEnum>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<CommentTimestampFilter>,
 }


### PR DESCRIPTION
Adds the dataset `query` endpoint to the api client. Needed for an internal project. 