### PR TITLE
remove double quote from charge warning message

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -22,7 +22,7 @@ pub fn ensure_uip_user_consents_to_ai_unit_charge(base_url: &Url) -> Result<()> 
         .with_prompt(
             r#"🚨⚠️ 👉 CAUTION 👈⚠️ 🚨
 
-The operation you are about to perform will charge AI units."
+The operation you are about to perform will charge AI units.
 
 Do you want to continue?"#,
         )


### PR DESCRIPTION
Remove erroneous `"` from no charge prompt