### PR TITLE
cli: retry requests when there is a connection issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleasd
+## Unreleased
 
 - Always retry on connection issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleasd
+
+- Always retry on connection issues
+
 ## v0.16.1
 - Add attachments to `sync-raw-email`
 

--- a/api/src/retry.rs
+++ b/api/src/retry.rs
@@ -63,7 +63,7 @@ impl Retrier {
                 Ok(response) if response.status().is_server_error() => {
                     warn_and_sleep!(format!("{} for {}", response.status(), response.url()))
                 }
-                Err(error) if error.is_timeout() => warn_and_sleep!(error),
+                Err(error) if error.is_timeout() || error.is_connect() => warn_and_sleep!(error),
                 // If anything else, just return it immediately
                 result => return result,
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -104,7 +104,7 @@ fn client_from_args(args: &Args, config: &ReinferConfig) -> Result<Client> {
     // Retry everything but the very first request.
     // Retry wait schedule is [5s, 10s, 20s, fail]. (Plus the time for each attempt to timeout.)
     let retry_config = RetryConfig {
-        strategy: RetryStrategy::Automatic,
+        strategy: RetryStrategy::Always,
         max_retry_count: 3,
         base_wait: std::time::Duration::from_secs_f64(5.0),
         backoff_factor: 2.0,


### PR DESCRIPTION
Retry requests when there is a connection issues. Helps prevent long running jobs from failing during deployments.