### PR TITLE
cli: retry too many request responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Retry TOO_MANY_REQUESTS
+
 ## v0.17.1
 - Support markup in signatures
 - Fix bug where annotations may have been uploaded before comments, causing a failure


### PR DESCRIPTION
Retry when we receive `429`