### PR TITLE
cli: retry on request errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Add label filter when downloading comments with predictions
+- Retry requests on request error
 
 ## v0.17.2
 - Retry TOO_MANY_REQUESTS

--- a/api/src/retry.rs
+++ b/api/src/retry.rs
@@ -68,7 +68,9 @@ impl Retrier {
                 Ok(response) if Self::should_retry(response.status()) => {
                     warn_and_sleep!(format!("{} for {}", response.status(), response.url()))
                 }
-                Err(error) if error.is_timeout() || error.is_connect() => warn_and_sleep!(error),
+                Err(error) if error.is_timeout() || error.is_connect() || error.is_request() => {
+                    warn_and_sleep!(error)
+                }
                 // If anything else, just return it immediately
                 result => return result,
             }


### PR DESCRIPTION
So we retry request errors caused by deployments