### PR TITLE
cli: add ability to filter on user properties when getting comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+-Add ability to filter on user properties when getting comments
+
 ## v0.18.1
 - Add comment id to document object in api
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -15,7 +15,8 @@ use reqwest::{
 use resources::{
     dataset::{
         QueryRequestParams, QueryResponse,
-        StatisticsRequestParams as DatasetStatisticsRequestParams,
+        StatisticsRequestParams as DatasetStatisticsRequestParams, SummaryRequestParams,
+        SummaryResponse,
     },
     documents::{Document, SyncRawEmailsRequest, SyncRawEmailsResponse},
     project::ForceDeleteProject,
@@ -665,6 +666,18 @@ impl Client {
             .user)
     }
 
+    pub fn dataset_summary(
+        &self,
+        dataset_name: &DatasetFullName,
+        params: &SummaryRequestParams,
+    ) -> Result<SummaryResponse> {
+        self.post::<_, _, SummaryResponse>(
+            self.endpoints.dataset_summary(dataset_name)?,
+            serde_json::to_value(params).expect("summary params serialization error"),
+            Retry::Yes,
+        )
+    }
+
     pub fn query_dataset(
         &self,
         dataset_name: &DatasetFullName,
@@ -1252,6 +1265,13 @@ impl Endpoints {
             current_user,
             projects,
         })
+    }
+
+    fn dataset_summary(&self, dataset_name: &DatasetFullName) -> Result<Url> {
+        construct_endpoint(
+            &self.base,
+            &["api", "_private", "datasets", &dataset_name.0, "summary"],
+        )
     }
 
     fn query_dataset(&self, dataset_name: &DatasetFullName) -> Result<Url> {

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -111,6 +111,14 @@ pub enum OrderEnum {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct SummaryRequestParams {
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    pub attribute_filters: Vec<AttributeFilter>,
+
+    pub filter: CommentFilter,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct QueryRequestParams {
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     pub attribute_filters: Vec<AttributeFilter>,
@@ -123,6 +131,27 @@ pub struct QueryRequestParams {
     pub limit: usize,
 
     pub order: OrderEnum,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UserPropertySummary {
+    pub full_name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UserPropertySummaryList {
+    pub string: Vec<UserPropertySummary>,
+    pub number: Vec<UserPropertySummary>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Summary {
+    pub user_properties: UserPropertySummaryList,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SummaryResponse {
+    pub summary: Summary,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/cli/src/commands/get/comments.rs
+++ b/cli/src/commands/get/comments.rs
@@ -101,9 +101,9 @@ pub struct GetManyCommentsArgs {
     /// The user property to use
     property_filter: Option<StructExt<UserPropertiesFilter>>,
 
-    #[structopt(long = "interative-user-property-filter")]
+    #[structopt(long = "interactive-user-property-filter")]
     /// Open a dialog to interative construct the user property filter
-    interative_property_filter: bool,
+    interactive_property_filter: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -240,7 +240,7 @@ pub fn get_many(client: &Client, args: &GetManyCommentsArgs) -> Result<()> {
         path,
         label_filter,
         property_filter: user_property_filter,
-        interative_property_filter,
+        interactive_property_filter: interative_property_filter,
     } = args;
 
     let by_timerange = from_timestamp.is_some() || to_timestamp.is_some();


### PR DESCRIPTION
Adds ability to filter on user properties when getting comments, currently only supports string properties with `any_of` filter