### PR TITLE
cli: do not print bucket updated timestamp

### DIFF
--- a/api/src/resources/bucket.rs
+++ b/api/src/resources/bucket.rs
@@ -19,7 +19,6 @@ pub struct Bucket {
     pub name: Name,
     pub owner: Username,
     pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
     #[serde(default)]
     pub transform_tag: Option<TransformTag>,
 }

--- a/cli/src/printer.rs
+++ b/cli/src/printer.rs
@@ -58,7 +58,7 @@ pub trait DisplayTable {
 
 impl DisplayTable for Bucket {
     fn to_table_headers() -> Row {
-        row![bFg => "Name", "ID", "Created (UTC)", "Updated (UTC)", "Transform Tag"]
+        row![bFg => "Name", "ID", "Created (UTC)", "Transform Tag"]
     }
 
     fn to_table_row(&self) -> Row {
@@ -67,7 +67,6 @@ impl DisplayTable for Bucket {
             full_name,
             self.id.0,
             self.created_at.format("%Y-%m-%d %H:%M:%S"),
-            self.updated_at.format("%Y-%m-%d %H:%M:%S"),
             match &self.transform_tag {
                 Some(transform_tag) => transform_tag.0.as_str().into(),
                 None => "missing".dimmed(),


### PR DESCRIPTION
It is my understanding that none of the [update-related timestamps on bucket](https://github.com/reinfer/platform/blob/master/store/reinfer/store/bucket/resources.py#L79-L83) are currently being updated (following transition from bucket states to folder states), and we don't have a "most recent folder state update timestamp" field either, so this PR removes the "Updated" column from the CLI's bucket output, as it is now wrong.