### PR TITLE
commands: filter get users by project and permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add ability to get dataset stats
 - Show Global Permissions in `get users`
 - Upgrade `ordered-float` version, which is exposed in the public crate api.
+- Add ability to filter users by project and permission
 
 ## v0.19.0
 

--- a/cli/src/commands/get/users.rs
+++ b/cli/src/commands/get/users.rs
@@ -1,5 +1,5 @@
-use anyhow::{Context, Result};
-use reinfer_client::{Client, UserIdentifier};
+use anyhow::{bail, Context, Result};
+use reinfer_client::{Client, ProjectName, ProjectPermission, UserIdentifier};
 use structopt::StructOpt;
 
 use crate::printer::Printer;
@@ -9,24 +9,54 @@ pub struct GetUsersArgs {
     #[structopt(short = "u", long = "user")]
     /// Use to retrieve a single user with the provided id
     user: Option<UserIdentifier>,
+
+    #[structopt(short = "o", long = "project")]
+    /// Filter users by a given project
+    project_name_filter: Option<ProjectName>,
+
+    #[structopt(short = "p", long = "permission")]
+    /// Filter users by a given project permission
+    project_permission_filter: Option<ProjectPermission>,
 }
 
 pub fn get(client: &Client, args: &GetUsersArgs, printer: &Printer) -> Result<()> {
-    let GetUsersArgs { user } = args;
-    match user {
+    let GetUsersArgs {
+        user,
+        project_name_filter,
+        project_permission_filter,
+    } = args;
+
+    if project_name_filter.is_none() && project_permission_filter.is_some() {
+        bail!("You cannot filter on `permission` without a `project`")
+    }
+
+    let mut users = match user {
         Some(user_id) => {
             let user = client
                 .get_user(user_id.clone())
                 .context("Operation to get user has failed.")?;
-            printer.print_resources(&[user])
+            vec![user]
         }
-        None => {
-            let users = client
-                .get_users()
-                .context("Operation to list users has failed.")?;
-            printer.print_resources(&users)
-        }
+        None => client
+            .get_users()
+            .context("Operation to list users has failed.")?,
+    };
+
+    if let Some(project_name) = project_name_filter {
+        users.retain(|user| {
+            user.project_permissions
+                .get(project_name)
+                .is_some_and(|user_permissions| {
+                    if let Some(project_permission) = project_permission_filter {
+                        user_permissions.contains(project_permission)
+                    } else {
+                        true
+                    }
+                })
+        })
     }
+
+    printer.print_resources(&users)
 }
 
 pub fn get_current_user(client: &Client, printer: &Printer) -> Result<()> {

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -379,7 +379,7 @@ fn test_create_dataset_wrong_model_family() {
         .unwrap();
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr)
-        .contains("API request failed with 400 Bad Request: 'non-existent-family' is not one of"))
+        .contains("API request failed with 400 Bad Request: Invalid request - Unsupported model family: non-existent-family"))
 }
 
 #[test]


### PR DESCRIPTION
Allows you to filter `get users` by a project and permissions