### PR TITLE
fix(api): update fetch stream url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Fix url used for fetching streams
+- Return `is_end_sequence` on stream fetch
 
 ## v0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Fix url used for fetching streams
+
 ## v0.20.0
 
 - Add ability to get dataset stats

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1308,7 +1308,9 @@ impl Endpoints {
                 "v1",
                 "datasets",
                 &stream_name.dataset.0,
+                "streams",
                 &stream_name.stream.0,
+                "fetch",
             ],
         )
     }

--- a/api/src/resources/stream.rs
+++ b/api/src/resources/stream.rs
@@ -134,6 +134,7 @@ pub struct Batch {
     pub results: Vec<StreamResult>,
     pub filtered: u32,
     pub sequence_id: SequenceId,
+    pub is_end_sequence: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Fixes the url we use for fetching streams and also makes sure we return an additional url we're adding to the fetch response 