### PR TITLE
add more stream label validation stats

### DIFF
--- a/cli/src/commands/get/streams.rs
+++ b/cli/src/commands/get/streams.rs
@@ -169,8 +169,8 @@ fn red_if_lower_green_otherwise(test: NotNan<f64>, threshold: NotNan<f64>) -> Co
     let diff = test - threshold;
 
     match test {
-        test if test < threshold => format!("{test_str} ({diff:.3})").red(),
-        test if test > threshold => format!("{test_str} (+{diff:.3})").green(),
+        test if test < threshold => format!("{test_str} ({diff:+.3})").red(),
+        test if test > threshold => format!("{test_str} ({diff:+.3})").green(),
         _ => test_str.green(),
     }
 }


### PR DESCRIPTION
Adds some additional data for the stream stats. Namely;
 - What precision would you expect if the recall was the same. What threshold do you need for that?
 - What precision would you expect if the precision was the same. What threshold do you need for that?