### PR TITLE
feat(comments): add messages filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Add messages filters
+
 ## v0.21.3 
 - Reduce batch size for parse emls
 

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -67,11 +67,11 @@ pub enum ReviewedFilterEnum {
 type UserPropertyName = String;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UserPropertiesFilter(pub HashMap<UserPropertyName, UserPropertyFilterKind>);
+pub struct UserPropertiesFilter(pub HashMap<UserPropertyName, PropertyFilterKind>);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum UserPropertyFilterKind {
+pub enum PropertyFilterKind {
     OneOf(Vec<PropertyValue>),
 }
 
@@ -89,6 +89,18 @@ pub struct CommentFilter {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
     pub sources: Vec<SourceId>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub messages: Option<MessagesFilter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MessagesFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<PropertyFilterKind>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<PropertyFilterKind>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -301,7 +301,7 @@ pub(crate) struct UpdateResponse {
 #[cfg(test)]
 mod tests {
     use crate::resources::comment::{
-        CommentTimestampFilter, UserPropertiesFilter, UserPropertyFilterKind,
+        CommentTimestampFilter, PropertyFilterKind, UserPropertiesFilter,
     };
 
     use super::*;
@@ -431,7 +431,7 @@ mod tests {
     pub fn test_serialize_user_properties_request_params() {
         let user_property_filter = UserPropertiesFilter(HashMap::from([(
             "string:Generation Tag".to_string(),
-            UserPropertyFilterKind::OneOf(vec![PropertyValue::String(
+            PropertyFilterKind::OneOf(vec![PropertyValue::String(
                 "72b01fe7-ef2e-481e-934d-bc2fe0ca9b06".to_string(),
             )]),
         )]));


### PR DESCRIPTION
Adds the ability to filter on senders and recipients when running `get comments`