### PR TITLE
fix(labelling): Fix label prediction type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- Fix a bug where some label annotations cannot be applied
+
 # v0.22.1
 - minor api improvements 
 

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -625,8 +625,14 @@ pub struct Label {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub enum PredictedLabelName {
+    Parts(Vec<String>),
+    String(LabelName),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct PredictedLabel {
-    pub name: Vec<String>,
+    pub name: PredictedLabelName,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sentiment: Option<NotNan<f64>>,
     pub probability: NotNan<f64>,

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -625,6 +625,7 @@ pub struct Label {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
 pub enum PredictedLabelName {
     Parts(Vec<String>),
     String(LabelName),

--- a/cli/src/commands/get/comments.rs
+++ b/cli/src/commands/get/comments.rs
@@ -8,8 +8,8 @@ use regex::Regex;
 use reinfer_client::{
     resources::{
         comment::{
-            CommentTimestampFilter, MessagesFilter, PropertyFilterKind, ReviewedFilterEnum,
-            UserPropertiesFilter,
+            CommentTimestampFilter, MessagesFilter, PredictedLabelName, PropertyFilterKind,
+            ReviewedFilterEnum, UserPropertiesFilter,
         },
         dataset::{
             Attribute, AttributeFilter, AttributeFilterEnum, OrderEnum, QueryRequestParams,
@@ -613,7 +613,9 @@ fn get_comments_from_uids(
                                     auto_threshold_labels
                                         .iter()
                                         .map(|auto_threshold_label| PredictedLabel {
-                                            name: auto_threshold_label.name.to_owned(),
+                                            name: PredictedLabelName::String(LabelName(
+                                                auto_threshold_label.name.join(" > "),
+                                            )),
                                             sentiment: None,
                                             probability: auto_threshold_label.probability,
                                             auto_thresholds: Some(


### PR DESCRIPTION
Fixes this mistake: https://github.com/reinfer/cli/commit/f2edc087acaea57afb4b89c28e9e07b3670a9003