### PR TITLE
Add support for setting 'auto-increase-up-to' in quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,31 @@
+# Unreleased
+
+- Added support for `--auto-increase-up-to` when creating quotas.
+
 # v0.22.2
+
 - Fix a bug where some label annotations cannot be applied
 
 # v0.22.1
-- minor api improvements 
+
+- minor api improvements
 
 # v0.22.0
+
 - Add integration commands
 
-# v0.21.5 
-- Fix a bug where stream responses were not correctly parsed 
-- Fix a bug where streams were not correctly advanced 
+# v0.21.5
+
+- Fix a bug where stream responses were not correctly parsed
+- Fix a bug where streams were not correctly advanced
 
 # v0.21.4
+
 - Add messages filters
 - Fixes `required` field error when interacting with datasets
 
-## v0.21.3 
+## v0.21.3
+
 - Reduce batch size for parse emls
 
 ## v0.21.2

--- a/api/src/resources/quota.rs
+++ b/api/src/resources/quota.rs
@@ -93,6 +93,13 @@ impl Display for TenantQuotaKind {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Default)]
 pub struct CreateQuota {
     pub hard_limit: u64,
+
+    // It is very important for this value not to be serialized if it is `None`.
+    // This is because the API will interpret `null` as "reset the auto-increase-up-to" value to
+    // its default value. If the field is not set, then the value will be left unchanged (which is
+    // what we want).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_increase_up_to: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Copy)]

--- a/cli/src/commands/create/quota.rs
+++ b/cli/src/commands/create/quota.rs
@@ -27,6 +27,10 @@ pub struct CreateQuotaArgs {
     #[structopt(long = "limit")]
     /// New value of the quota to set
     hard_limit: u64,
+
+    #[structopt(long = "auto-increase-up-to")]
+    /// If set, will also change the `auto-increase-up-to` value of the quota
+    auto_increase_up_to: Option<u64>,
 }
 
 pub fn create(client: &Client, args: &CreateQuotaArgs) -> Result<()> {
@@ -35,6 +39,7 @@ pub fn create(client: &Client, args: &CreateQuotaArgs) -> Result<()> {
         uipath_tenant_id,
         tenant_quota_kind,
         hard_limit,
+        auto_increase_up_to,
     } = args;
 
     let tenant_id: TenantId = match (reinfer_tenant_id, uipath_tenant_id) {
@@ -53,6 +58,7 @@ pub fn create(client: &Client, args: &CreateQuotaArgs) -> Result<()> {
             *tenant_quota_kind,
             CreateQuota {
                 hard_limit: *hard_limit,
+                auto_increase_up_to: *auto_increase_up_to,
             },
         )
         .context("Operation to set quota has failed")?;


### PR DESCRIPTION
Add support for setting `auto-increase-up-to` in quotas.

If the `--auto-increase-up-to` flag is passed to `re create quotas`, then the value will be set in the database for the relevant tenant.
Otherwise, it will just not be changed.