### PR TITLE
It is better to use the repository field

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "reinfer-client"
 version = "0.24.0"
 description = "API client for Re:infer, the conversational data intelligence platform"
-homepage = "https://github.com/reinfer/cli"
+repository = "https://github.com/reinfer/cli"
 readme = "README.md"
 authors = ["reinfer Ltd. <eng@reinfer.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).