### PR TITLE
feat(commands): add lossy flag when creating annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add `config parse-from-url` command for parsing configuration from a URL
 - Add ability to download attachments for comments
 - Increase default http timeout to 120s
+- Add `--lossy` flag when creating annotations
 
 # v0.28.0
 - Add general fields to `create datasets`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Add `config parse-from-url` command for parsing configuration from a URL
 - Add ability to download attachments for comments
 - Increase default http timeout to 120s
-- Add `--lossy` flag when creating annotations
+- Add `--resume-on-error` flag when creating annotations
 
 # v0.28.0
 - Add general fields to `create datasets`

--- a/cli/src/commands/create/annotations.rs
+++ b/cli/src/commands/create/annotations.rs
@@ -201,6 +201,7 @@ pub fn upload_batch_of_annotations(
 
     if let Ok(error) = error_receiver.try_recv() {
         if resume_on_error {
+            annotations_to_upload.clear();
             Ok(())
         } else {
             Err(error)

--- a/cli/src/commands/create/comments.rs
+++ b/cli/src/commands/create/comments.rs
@@ -473,11 +473,15 @@ pub struct Statistics {
     updated: AtomicUsize,
     unchanged: AtomicUsize,
     annotations: AtomicUsize,
+    failed_annotations: AtomicUsize,
 }
 
 impl AnnotationStatistic for Statistics {
     fn add_annotation(&self) {
         self.annotations.fetch_add(1, Ordering::SeqCst);
+    }
+    fn add_failed_annotation(&self) {
+        self.failed_annotations.fetch_add(1, Ordering::SeqCst);
     }
 }
 
@@ -490,6 +494,7 @@ impl Statistics {
             updated: AtomicUsize::new(0),
             unchanged: AtomicUsize::new(0),
             annotations: AtomicUsize::new(0),
+            failed_annotations: AtomicUsize::new(0),
         }
     }
 
@@ -535,6 +540,11 @@ impl Statistics {
     fn num_annotations(&self) -> usize {
         self.annotations.load(Ordering::SeqCst)
     }
+
+    #[inline]
+    fn num_failed_annotations(&self) -> usize {
+        self.failed_annotations.load(Ordering::SeqCst)
+    }
 }
 
 /// Detailed statistics - only make sense if using --overwrite (i.e. exclusively sync endpoint)
@@ -546,10 +556,11 @@ fn detailed_statistics(statistics: &Statistics) -> (u64, String) {
     let num_updated = statistics.num_updated();
     let num_unchanged = statistics.num_unchanged();
     let num_annotations = statistics.num_annotations();
+    let num_failed_annotations = statistics.num_failed_annotations();
     (
         bytes_read as u64,
         format!(
-            "{} {}: {} {} {} {} {} {} [{} {}]",
+            "{} {}: {} {} {} {} {} {} [{} {}{}]",
             num_uploaded.to_string().bold(),
             "comments".dimmed(),
             num_new,
@@ -560,6 +571,11 @@ fn detailed_statistics(statistics: &Statistics) -> (u64, String) {
             "nop".dimmed(),
             num_annotations,
             "annotations".dimmed(),
+            if num_failed_annotations > 0 {
+                format!(" {} {}", num_failed_annotations, "skipped".dimmed())
+            } else {
+                "".to_string()
+            }
         ),
     )
 }
@@ -569,14 +585,20 @@ fn basic_statistics(statistics: &Statistics) -> (u64, String) {
     let bytes_read = statistics.bytes_read();
     let num_uploaded = statistics.num_uploaded();
     let num_annotations = statistics.num_annotations();
+    let num_failed_annotations = statistics.num_failed_annotations();
     (
         bytes_read as u64,
         format!(
-            "{} {} [{} {}]",
+            "{} {} [{} {}{}]",
             num_uploaded.to_string().bold(),
             "comments".dimmed(),
             num_annotations,
             "annotations".dimmed(),
+            if num_failed_annotations > 0 {
+                format!(" {} {}", num_failed_annotations, "skipped".dimmed())
+            } else {
+                "".to_string()
+            }
         ),
     )
 }

--- a/cli/src/commands/create/comments.rs
+++ b/cli/src/commands/create/comments.rs
@@ -75,9 +75,9 @@ pub struct CreateCommentsArgs {
     /// Consent to ai unit charge. Suppresses confirmation prompt.
     yes: bool,
 
-    #[structopt(long)]
+    #[structopt(long = "resume-on-error")]
     /// Whether to attempt to resume processing on error
-    lossy: bool,
+    resume_on_error: bool,
 }
 
 pub fn create(client: &Client, args: &CreateCommentsArgs, pool: &mut Pool) -> Result<()> {
@@ -156,7 +156,7 @@ pub fn create(client: &Client, args: &CreateCommentsArgs, pool: &mut Pool) -> Re
                 args.use_moon_forms,
                 args.no_charge,
                 pool,
-                args.lossy,
+                args.resume_on_error,
             )?;
             if let Some(mut progress) = progress {
                 progress.done();
@@ -185,7 +185,7 @@ pub fn create(client: &Client, args: &CreateCommentsArgs, pool: &mut Pool) -> Re
                 args.use_moon_forms,
                 args.no_charge,
                 pool,
-                args.lossy,
+                args.resume_on_error,
             )?;
             statistics
         }
@@ -336,7 +336,7 @@ fn upload_comments_from_reader(
     use_moon_forms: bool,
     no_charge: bool,
     pool: &mut Pool,
-    lossy: bool,
+    resume_on_error: bool,
 ) -> Result<()> {
     assert!(batch_size > 0);
 
@@ -422,7 +422,7 @@ fn upload_comments_from_reader(
                     dataset_name,
                     use_moon_forms,
                     pool,
-                    lossy,
+                    resume_on_error,
                 )?;
             }
         }
@@ -450,7 +450,7 @@ fn upload_comments_from_reader(
                 dataset_name,
                 use_moon_forms,
                 pool,
-                lossy,
+                resume_on_error,
             )?;
         }
     }
@@ -557,6 +557,12 @@ fn detailed_statistics(statistics: &Statistics) -> (u64, String) {
     let num_unchanged = statistics.num_unchanged();
     let num_annotations = statistics.num_annotations();
     let num_failed_annotations = statistics.num_failed_annotations();
+    let failed_annotations_string = if num_failed_annotations > 0 {
+        format!(" {num_failed_annotations} {}", "skipped".dimmed())
+    } else {
+        String::new()
+    };
+
     (
         bytes_read as u64,
         format!(
@@ -571,11 +577,7 @@ fn detailed_statistics(statistics: &Statistics) -> (u64, String) {
             "nop".dimmed(),
             num_annotations,
             "annotations".dimmed(),
-            if num_failed_annotations > 0 {
-                format!(" {} {}", num_failed_annotations, "skipped".dimmed())
-            } else {
-                "".to_string()
-            }
+            failed_annotations_string
         ),
     )
 }
@@ -586,6 +588,12 @@ fn basic_statistics(statistics: &Statistics) -> (u64, String) {
     let num_uploaded = statistics.num_uploaded();
     let num_annotations = statistics.num_annotations();
     let num_failed_annotations = statistics.num_failed_annotations();
+    let failed_annotations_string = if num_failed_annotations > 0 {
+        format!(" {num_failed_annotations} {}", "skipped".dimmed())
+    } else {
+        String::new()
+    };
+
     (
         bytes_read as u64,
         format!(
@@ -594,11 +602,7 @@ fn basic_statistics(statistics: &Statistics) -> (u64, String) {
             "comments".dimmed(),
             num_annotations,
             "annotations".dimmed(),
-            if num_failed_annotations > 0 {
-                format!(" {} {}", num_failed_annotations, "skipped".dimmed())
-            } else {
-                "".to_string()
-            }
+            failed_annotations_string
         ),
     )
 }

--- a/cli/src/commands/create/comments.rs
+++ b/cli/src/commands/create/comments.rs
@@ -74,6 +74,10 @@ pub struct CreateCommentsArgs {
     #[structopt(short = "y", long = "yes")]
     /// Consent to ai unit charge. Suppresses confirmation prompt.
     yes: bool,
+
+    #[structopt(long)]
+    /// Whether to attempt to resume processing on error
+    lossy: bool,
 }
 
 pub fn create(client: &Client, args: &CreateCommentsArgs, pool: &mut Pool) -> Result<()> {
@@ -152,6 +156,7 @@ pub fn create(client: &Client, args: &CreateCommentsArgs, pool: &mut Pool) -> Re
                 args.use_moon_forms,
                 args.no_charge,
                 pool,
+                args.lossy,
             )?;
             if let Some(mut progress) = progress {
                 progress.done();
@@ -180,6 +185,7 @@ pub fn create(client: &Client, args: &CreateCommentsArgs, pool: &mut Pool) -> Re
                 args.use_moon_forms,
                 args.no_charge,
                 pool,
+                args.lossy,
             )?;
             statistics
         }
@@ -330,6 +336,7 @@ fn upload_comments_from_reader(
     use_moon_forms: bool,
     no_charge: bool,
     pool: &mut Pool,
+    lossy: bool,
 ) -> Result<()> {
     assert!(batch_size > 0);
 
@@ -415,6 +422,7 @@ fn upload_comments_from_reader(
                     dataset_name,
                     use_moon_forms,
                     pool,
+                    lossy,
                 )?;
             }
         }
@@ -442,6 +450,7 @@ fn upload_comments_from_reader(
                 dataset_name,
                 use_moon_forms,
                 pool,
+                lossy,
             )?;
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -203,15 +203,26 @@ fn find_configuration(args: &Args) -> Result<PathBuf> {
     Ok(config_path)
 }
 
+pub fn print_error_as_warning(error: &anyhow::Error) {
+    warn!("An error occurred. Resuming...:");
+    for cause in error.chain() {
+        warn!(" |- {}", cause);
+    }
+}
+
+pub fn print_error(error: &anyhow::Error) {
+    error!("An error occurred:");
+    for cause in error.chain() {
+        error!(" |- {}", cause);
+    }
+}
+
 fn main() {
     let args = Args::from_args();
     utils::init_env_logger(args.verbose);
 
     if let Err(error) = run(args) {
-        error!("An error occurred:");
-        for cause in error.chain() {
-            error!(" |- {}", cause);
-        }
+        print_error(&error);
 
         #[cfg(feature = "backtrace")]
         {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -203,26 +203,15 @@ fn find_configuration(args: &Args) -> Result<PathBuf> {
     Ok(config_path)
 }
 
-pub fn print_error_as_warning(error: &anyhow::Error) {
-    warn!("An error occurred. Resuming...");
-    for cause in error.chain() {
-        warn!(" |- {}", cause);
-    }
-}
-
-pub fn print_error(error: &anyhow::Error) {
-    error!("An error occurred:");
-    for cause in error.chain() {
-        error!(" |- {}", cause);
-    }
-}
-
 fn main() {
     let args = Args::from_args();
     utils::init_env_logger(args.verbose);
 
     if let Err(error) = run(args) {
-        print_error(&error);
+        error!("An error occurred:");
+        for cause in error.chain() {
+            error!(" |- {}", cause);
+        }
 
         #[cfg(feature = "backtrace")]
         {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -204,7 +204,7 @@ fn find_configuration(args: &Args) -> Result<PathBuf> {
 }
 
 pub fn print_error_as_warning(error: &anyhow::Error) {
-    warn!("An error occurred. Resuming...:");
+    warn!("An error occurred. Resuming...");
     for cause in error.chain() {
         warn!(" |- {}", cause);
     }


### PR DESCRIPTION
Adding a flag to attempt to resume processing when operations fail. Starting with annotations but could later be used for comments also 