### PR TITLE
feat(commands): add resume on error for comments and emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Increase default http timeout to 120s
 - Add `--resume-on-error` flag when creating annotations
 - Remove `--use-moon-forms` flag
+- Add `--resume-on-error` flag when creating comments / emails
 
 # v0.28.0
 - Add general fields to `create datasets`

--- a/api/src/resources/email.rs
+++ b/api/src/resources/email.rs
@@ -1,3 +1,4 @@
+use crate::{ReducibleResponse, SplittableRequest};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -50,12 +51,29 @@ pub struct NewEmail {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub(crate) struct PutEmailsRequest<'request> {
-    pub emails: &'request [NewEmail],
+pub(crate) struct PutEmailsRequest {
+    pub emails: Vec<NewEmail>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+impl SplittableRequest for PutEmailsRequest {
+    fn split(self) -> impl Iterator<Item = Self>
+    where
+        Self: Sized,
+    {
+        self.emails.into_iter().map(|email| Self {
+            emails: vec![email],
+        })
+    }
+
+    fn count(&self) -> usize {
+        self.emails.len()
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct PutEmailsResponse {}
+
+impl ReducibleResponse for PutEmailsResponse {}
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct Continuation(pub String);

--- a/cli/src/commands/parse/mod.rs
+++ b/cli/src/commands/parse/mod.rs
@@ -114,7 +114,7 @@ fn upload_batch_of_new_emails(
     no_charge: bool,
     statistics: &Arc<Statistics>,
 ) -> Result<()> {
-    client.put_emails(bucket, emails, no_charge)?;
+    client.put_emails(bucket, emails.to_vec(), no_charge)?;
     statistics.add_uploaded(emails.len());
     Ok(())
 }


### PR DESCRIPTION
Adds a `--resume-on-error` flag for uploading comments and emails. When the api returns an error the CLI will split a particular batch into individual requests, attempt each one individually and skip any individual request that fail 