### PR TITLE
fix(api): Always serialize assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `--resume-on-error` flag when creating annotations
 - Remove `--use-moon-forms` flag
 - Add `--resume-on-error` flag when creating comments / emails
+- Serialize assigned on moon_forms if empty vec
 
 # v0.28.0
 - Add general fields to `create datasets`

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -782,7 +782,7 @@ pub struct MoonFormLabelCaptures {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct MoonForm {
     pub group: LabelGroupName,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default)]
     pub assigned: Vec<MoonFormLabelCaptures>,
     #[serde(skip_serializing_if = "should_skip_serializing_optional_vec", default)]
     pub predicted: Option<Vec<MoonFormLabelCaptures>>,
@@ -804,7 +804,7 @@ pub struct NewMoonFormLabelCaptures {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct NewMoonForm {
     pub group: LabelGroupName,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(default)]
     pub assigned: Vec<NewMoonFormLabelCaptures>,
 }
 


### PR DESCRIPTION
Defaulting to empty vec if not present so backups impacted by this won't be broken