### PR TITLE
chore(api): retry put comments requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Retry when putting comments
 - Add ability to upload attachment content for comments
 
 # v0.29.0

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -510,7 +510,7 @@ impl Client {
             self.endpoints.put_comments(source_name)?,
             PutCommentsRequest { comments },
             Some(NoChargeQuery { no_charge }),
-            Retry::No,
+            Retry::Yes,
         )
     }
 
@@ -525,7 +525,7 @@ impl Client {
             &self.endpoints.put_comments(source_name)?,
             &Some(PutCommentsRequest { comments }),
             &Some(NoChargeQuery { no_charge }),
-            &Retry::No,
+            &Retry::Yes,
         )
     }
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -505,6 +505,9 @@ impl Client {
         comments: Vec<NewComment>,
         no_charge: bool,
     ) -> Result<SplitableRequestResponse<PutCommentsResponse>> {
+        // Retrying here despite the potential for 409's in order to increase reliability when
+        // working with poor connection
+
         self.splitable_request(
             Method::PUT,
             self.endpoints.put_comments(source_name)?,
@@ -520,6 +523,8 @@ impl Client {
         comments: Vec<NewComment>,
         no_charge: bool,
     ) -> Result<PutCommentsResponse> {
+        // Retrying here despite the potential for 409's in order to increase reliability when
+        // working with poor connection
         self.request(
             &Method::PUT,
             &self.endpoints.put_comments(source_name)?,


### PR DESCRIPTION
May result on 409 on retry if the put actually worked, but adding anyway as (anecdotally) most of the time the connection doesn't make it to us