### PR TITLE
feat(commands): add package commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased 
 - Add --detach-bucket to `update source` 
+- Add package commands
 
 # v0.36.3
 - Fix a typo in get datasets docs 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +42,15 @@ name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -78,7 +98,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "instant",
  "rand",
 ]
@@ -102,10 +122,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bumpalo"
-version = "3.12.0"
+name = "bitflags"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -120,11 +155,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -172,12 +228,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "textwrap",
  "unicode-width",
 ]
@@ -217,6 +283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,12 +305,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
+name = "cpufeatures"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -358,6 +470,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
+name = "deranged"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.34",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +515,17 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "dirs"
@@ -457,6 +607,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -586,6 +742,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +760,20 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -608,7 +788,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -620,6 +800,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -659,6 +845,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -784,8 +979,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -798,6 +1003,15 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -854,11 +1068,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "js-sys"
-version = "0.3.61"
+name = "jobserver"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -902,12 +1126,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
-name = "log"
-version = "0.4.17"
+name = "lockfree-object-pool"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
 dependencies = [
- "cfg-if",
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -935,9 +1183,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1013,6 +1261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,9 +1303,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
@@ -1059,7 +1313,7 @@ version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1129,6 +1383,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,15 +1412,21 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1239,6 +1509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3866219251662ec3b26fc217e3e05bf9c4f84325234dfb96bf0bf840889e49"
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,7 +1542,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "serde",
 ]
 
@@ -1276,7 +1552,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1285,7 +1561,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "redox_syscall",
  "thiserror",
 ]
@@ -1344,6 +1620,7 @@ dependencies = [
  "structopt",
  "url",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -1412,7 +1689,7 @@ version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1459,7 +1736,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1528,11 +1805,11 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.20",
+ "time 0.3.41",
 ]
 
 [[package]]
@@ -1548,6 +1825,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1846,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"
@@ -1613,6 +1907,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1721,11 +2021,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
+ "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -1733,16 +2036,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -1834,6 +2138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,7 +2203,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -1931,27 +2241,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.84"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.34",
  "wasm-bindgen-shared",
 ]
 
@@ -1969,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1979,22 +2299,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.34",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -2137,6 +2460,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2485,90 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.34",
+]
+
+[[package]]
+name = "zip"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "febbe83a485467affa75a75d28dc7494acd2f819e549536c47d46b3089b56164"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "flate2",
+ "getrandom 0.3.2",
+ "hmac",
+ "indexmap 2.8.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "time 0.3.41",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/api/src/resources/attachments.rs
+++ b/api/src/resources/attachments.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::AttachmentReference;
 use serde::{Deserialize, Serialize};
 
@@ -18,4 +20,12 @@ pub struct AttachmentMetadata {
     pub attachment_reference: Option<AttachmentReference>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content_hash: Option<ContentHash>,
+}
+
+impl AttachmentMetadata {
+    pub fn extension(&self) -> Option<String> {
+        let path = Path::new(&self.name);
+        path.extension()
+            .map(|path| path.to_string_lossy().to_string())
+    }
 }

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -929,9 +929,9 @@ pub struct MoonFormFieldAnnotation {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct EntitySpanUtf16 {
     content_part: String,
-    message_index: i32,
-    utf16_byte_start: i32,
-    utf16_byte_end: i32,
+    message_index: u32,
+    utf16_byte_start: u32,
+    utf16_byte_end: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -944,8 +944,8 @@ pub struct MoonFormFieldAnnotationNew {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub struct DocumentSpan {
-    page_index: i32,
-    attachment_index: i32,
+    page_index: u32,
+    attachment_index: u32,
     polygon: PagePolygon,
 }
 
@@ -956,8 +956,8 @@ pub struct PagePolygon {
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub struct Vertex {
-    x: f32,
-    y: f32,
+    x: f64,
+    y: f64,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Eq)]

--- a/api/src/resources/comment.rs
+++ b/api/src/resources/comment.rs
@@ -262,12 +262,12 @@ impl ReducibleResponse for SyncCommentsResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct GetCommentResponse {
     pub comment: Comment,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Comment {
     pub id: Id,
     pub uid: Uid,
@@ -495,7 +495,7 @@ impl<'de> Visitor<'de> for PropertyMapVisitor {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct AnnotatedComment {
     pub comment: Comment,
     #[serde(skip_serializing_if = "should_skip_serializing_labelling")]
@@ -630,7 +630,7 @@ impl HasAnnotations for EitherLabelling {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct NewAnnotatedComment {
     pub comment: NewComment,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -781,42 +781,52 @@ pub struct NewEntities {
     pub dismissed: Vec<NewEntity>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct MoonFormCapture {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub fields: Vec<Entity>,
+    pub fields: Vec<MoonFormFieldAnnotation>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct MoonFormLabelCaptures {
     pub label: Label,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub captures: Vec<MoonFormCapture>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct MoonForm {
     pub group: LabelGroupName,
     #[serde(default)]
     pub assigned: Vec<MoonFormLabelCaptures>,
     #[serde(skip_serializing_if = "should_skip_serializing_optional_vec", default)]
     pub predicted: Option<Vec<MoonFormLabelCaptures>>,
+    #[serde(default)]
+    pub dismissed: Vec<MoonFormLabelCaptures>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct NewMoonFormCapture {
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub fields: Vec<NewEntity>,
+    pub fields: Vec<MoonFormFieldAnnotationNew>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct NewMoonFormLabelCaptures {
     pub label: Label,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub captures: Vec<NewMoonFormCapture>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct MoonFormDismissedUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub captures: Option<Vec<NewMoonFormLabelCaptures>>,
+    pub entities: Vec<MoonFormFieldAnnotationNew>,
+    #[serde(default)]
+    pub labels: Vec<Label>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct NewMoonForm {
     pub group: LabelGroupName,
     #[serde(default)]
@@ -900,6 +910,54 @@ pub struct Entity {
     pub spans: Vec<EntitySpan>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub field_id: Option<FieldId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct MoonFormFieldAnnotation {
+    pub name: String,
+    pub spans: Vec<EntitySpan>,
+    pub kind: EntityName,
+
+    pub formatted_value: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field_id: Option<FieldId>,
+
+    pub document_spans: Vec<DocumentSpan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct EntitySpanUtf16 {
+    content_part: String,
+    message_index: i32,
+    utf16_byte_start: i32,
+    utf16_byte_end: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct MoonFormFieldAnnotationNew {
+    pub name: String,
+    pub spans: Vec<EntitySpanUtf16>,
+    pub formatted_value: String,
+    pub document_spans: Vec<DocumentSpan>,
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct DocumentSpan {
+    page_index: i32,
+    attachment_index: i32,
+    polygon: PagePolygon,
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct PagePolygon {
+    vertices: Vec<Vertex>,
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct Vertex {
+    x: f32,
+    y: f32,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Eq)]

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -11,7 +11,7 @@ use crate::{
         source::Id as SourceId,
         user::Username,
     },
-    AnnotatedComment, CommentFilter, Continuation,
+    AnnotatedComment, CommentFilter, CommentId, Continuation, ProjectName,
 };
 use std::{
     fmt::{Display, Formatter, Result as FmtResult},
@@ -28,6 +28,26 @@ pub enum DatasetFlag {
     Qos,
     ZeroShotLabels,
     Ixp,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct IxpDatasetNew {
+    pub name: Name,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct CreateIxpDatasetRequest {
+    pub dataset: IxpDatasetNew,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct UploadIxpDocumentResponse {
+    pub comment_id: CommentId,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct CreateIxpDatasetResponse {
+    pub dataset: Dataset,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -71,10 +91,27 @@ impl Dataset {
     pub fn full_name(&self) -> FullName {
         FullName(format!("{}/{}", self.owner.0, self.name.0))
     }
+
+    pub fn has_flag(&self, flag: DatasetFlag) -> bool {
+        self.dataset_flags.contains(&flag)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct Name(pub String);
+
+impl Name {
+    pub fn with_project(self, project: &ProjectName) -> Result<FullName> {
+        FullName::from_str(&format!("{0}/{1}", project.0, self.0))
+    }
+}
+impl FromStr for Name {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Ok(Name(s.to_string()))
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct FullName(pub String);

--- a/api/src/resources/label_def.rs
+++ b/api/src/resources/label_def.rs
@@ -1,5 +1,6 @@
 use crate::resources::comment::should_skip_serializing_optional_vec;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct PretrainedId(pub String);
@@ -28,15 +29,37 @@ pub struct NewLabelDef {
     pub name: Name,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pretrained: Option<NewLabelDefPretrained>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
+    pub trainable: Option<bool>,
     #[serde(skip_serializing_if = "should_skip_serializing_optional_vec", default)]
     pub moon_form: Option<Vec<MoonFormFieldDef>>,
+}
+
+impl TryFrom<&LabelDef> for NewLabelDef {
+    type Error = crate::Error;
+    fn try_from(value: &LabelDef) -> Result<Self, Self::Error> {
+        let label_as_string = json!(value).to_string();
+
+        let result: NewLabelDef =
+            serde_json::from_str(&label_as_string).map_err(|err| crate::Error::Unknown {
+                message: "Could not parse new label def".to_string(),
+                source: Box::new(err),
+            })?;
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct LabelDefProperty {
+    pub name: String,
+    pub value: f64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -56,4 +79,15 @@ pub struct NewLabelDefPretrained {
 pub struct MoonFormFieldDef {
     pub name: String,
     pub kind: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct CreateOrUpdateLabelDefsBulkRequest {
+    pub label_defs: Vec<NewLabelDef>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct CreateOrUpdateLabelDefsBulkResponse {}

--- a/api/src/resources/source.rs
+++ b/api/src/resources/source.rs
@@ -133,6 +133,8 @@ pub enum SourceKind {
     Call,
     Chat,
     Unknown(Box<str>),
+    IxpRuntime,
+    IxpDesignTime,
 }
 
 impl FromStr for SourceKind {
@@ -142,6 +144,8 @@ impl FromStr for SourceKind {
         Ok(match string {
             "call" => SourceKind::Call,
             "chat" => SourceKind::Chat,
+            "ixp_runtime" => SourceKind::IxpRuntime,
+            "ixp_design" => SourceKind::IxpDesignTime,
             value => SourceKind::Unknown(value.into()),
         })
     }
@@ -156,6 +160,8 @@ impl Display for SourceKind {
                 SourceKind::Call => "call",
                 SourceKind::Chat => "chat",
                 SourceKind::Unknown(value) => value.as_ref(),
+                SourceKind::IxpRuntime => "ixp_runtime",
+                SourceKind::IxpDesignTime => "ixp_design",
             }
         )
     }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,6 +51,7 @@ libc = "0.2.169"
 itertools = "0.14.0"
 mime_guess = "2.0.5"
 libz-sys = { version = "1.1.8", features = ["static"] }
+zip = "2.6.0"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,7 +1,7 @@
 use crate::{
     commands::{
-        config::ConfigArgs, create::CreateArgs, delete::DeleteArgs, get::GetArgs, parse::ParseArgs,
-        update::UpdateArgs,
+        config::ConfigArgs, create::CreateArgs, delete::DeleteArgs, get::GetArgs,
+        package::PackageArgs, parse::ParseArgs, update::UpdateArgs,
     },
     printer::OutputFormat,
 };
@@ -110,6 +110,13 @@ pub enum Command {
     Parse {
         #[structopt(subcommand)]
         parse_args: ParseArgs,
+    },
+
+    #[structopt(name = "package")]
+    /// Create packages for moving data around
+    Package {
+        #[structopt(subcommand)]
+        package_args: PackageArgs,
     },
 }
 

--- a/cli/src/commands/create/annotations.rs
+++ b/cli/src/commands/create/annotations.rs
@@ -264,7 +264,7 @@ pub struct CommentIdComment {
     pub id: CommentId,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct NewAnnotation {
     pub comment: CommentIdComment,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod create;
 pub mod delete;
 pub mod get;
+pub mod package;
 pub mod parse;
 pub mod update;
 

--- a/cli/src/commands/package/download.rs
+++ b/cli/src/commands/package/download.rs
@@ -45,7 +45,7 @@ pub struct DownloadPackageArgs {
     batch_size: usize,
 
     #[structopt(long = "max-attachment-memory-mb", default_value = "256")]
-    /// Maximum number of kb to use to store attachments in memory
+    /// Maximum number of mb to use to store attachments in memory
     max_attachment_memory_mb: u64,
 }
 
@@ -197,7 +197,7 @@ fn package_batch_of_documents(
     });
 
     if let Ok(error) = error_receiver.try_recv() {
-        return Err(anyhow!("Failed to upload document {}", error));
+        return Err(anyhow!("Failed to download document {}", error));
     };
 
     drop(document_sender);

--- a/cli/src/commands/package/download.rs
+++ b/cli/src/commands/package/download.rs
@@ -1,0 +1,368 @@
+use std::{
+    fs::remove_file,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc::channel,
+        Arc,
+    },
+};
+
+use anyhow::{anyhow, Context, Result};
+use reinfer_client::{
+    resources::{
+        attachments::AttachmentMetadata,
+        dataset::{DatasetFlag, QueryRequestParams},
+    },
+    Client, CommentFilter, CommentId, Dataset, DatasetFullName, DatasetIdentifier, DatasetName,
+    HasAnnotations, SourceId,
+};
+use scoped_threadpool::Pool;
+use structopt::StructOpt;
+
+use crate::{
+    commands::package::{AttachmentKey, CommentBatchKey, PackageContentId, PackageWriter},
+    progress::Progress,
+    DEFAULT_PROJECT_NAME,
+};
+use colored::Colorize;
+
+#[derive(Debug, StructOpt)]
+pub struct DownloadPackageArgs {
+    /// The api name of the project
+    project: DatasetName,
+
+    /// Path to save the package to
+    #[structopt(short = "f", long = "file", parse(from_os_str))]
+    file: PathBuf,
+
+    #[structopt(long)]
+    /// Whether to overwrite existing package file
+    overwrite: bool,
+
+    #[structopt(long = "batch-size", default_value = "128")]
+    /// Number of comments to batch in a single request.
+    batch_size: usize,
+
+    #[structopt(long = "max-attachment-memory-mb", default_value = "256")]
+    /// Maximum number of kb to use to store attachments in memory
+    max_attachment_memory_mb: u64,
+}
+
+fn get_project(project: &DatasetName, client: &Client) -> Result<Dataset> {
+    let default_project_name = DEFAULT_PROJECT_NAME.clone();
+
+    let dataset = client
+        .get_dataset(DatasetIdentifier::FullName(
+            project.clone().with_project(&default_project_name)?,
+        ))
+        .context(format!(
+            "Could not get project with the name {0}",
+            project.0
+        ))?;
+
+    if !dataset.has_flag(DatasetFlag::Ixp) {
+        return Err(anyhow!(
+            "Can only get packages for Unstructured and Complex Document projects"
+        ));
+    }
+
+    Ok(dataset)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn package_source_contents(
+    dataset: &DatasetFullName,
+    source_id: &SourceId,
+    batch_size: usize,
+    package_writer: &mut PackageWriter,
+    client: &Client,
+    statistics: &Arc<Statistics>,
+    max_attachment_memory_mb: &u64,
+    pool: &mut Pool,
+) -> Result<()> {
+    let mut query = QueryRequestParams {
+        limit: Some(batch_size),
+        filter: CommentFilter {
+            sources: vec![source_id.clone()],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let source_comments_iter = client.get_dataset_query_iter(dataset, &mut query);
+
+    let mut documents: Vec<(AttachmentMetadata, AttachmentKey, SourceId, CommentId)> = Vec::new();
+
+    source_comments_iter
+        .enumerate()
+        .try_for_each(|(idx, result)| -> Result<()> {
+            let comments = result.context("Failed to read coment batch")?;
+
+            package_writer
+                .write_comment_batch(source_id, CommentBatchKey(idx), &comments)
+                .context("Failed to write comment batch")?;
+
+            statistics.add_comments(comments.len());
+            statistics.add_annotations(comments.iter().filter(|c| c.has_annotations()).count());
+
+            documents.append(
+                &mut comments
+                    .iter()
+                    .flat_map(|comment| {
+                        comment
+                            .comment
+                            .clone()
+                            .attachments
+                            .into_iter()
+                            .enumerate()
+                            .map(|(idx, attachment)| {
+                                (
+                                    attachment,
+                                    AttachmentKey(idx),
+                                    source_id.clone(),
+                                    comment.comment.id.clone(),
+                                )
+                            })
+                    })
+                    .collect(),
+            );
+
+            if should_package_batch_of_documents(&documents, max_attachment_memory_mb) {
+                package_batch_of_documents(&documents, statistics, package_writer, client, pool)
+                    .context("Failed to package document batch")?;
+                documents.clear();
+            }
+
+            Ok(())
+        })?;
+    package_batch_of_documents(&documents, statistics, package_writer, client, pool)
+}
+
+fn should_package_batch_of_documents(
+    documents: &[(AttachmentMetadata, AttachmentKey, SourceId, CommentId)],
+    max_attachment_memory_mb: &u64,
+) -> bool {
+    documents
+        .iter()
+        .map(|(attachment, _, _, _)| attachment.size)
+        .sum::<u64>()
+        / 1_000_000
+        >= *max_attachment_memory_mb
+}
+
+fn package_batch_of_documents(
+    documents: &[(AttachmentMetadata, AttachmentKey, SourceId, CommentId)],
+    statistics: &Arc<Statistics>,
+    package_writer: &mut PackageWriter,
+    client: &Client,
+    pool: &mut Pool,
+) -> Result<()> {
+    let (error_sender, error_receiver) = channel();
+    let (document_sender, document_receiver) = channel();
+
+    pool.scoped(|scope| {
+        documents
+            .iter()
+            .for_each(|(metadata, key, source_id, comment_id)| {
+                let error_sender = error_sender.clone();
+                let sender = document_sender.clone();
+                scope.execute(move || {
+                    let result = client.get_ixp_document(source_id, comment_id);
+
+                    let extension = metadata.extension();
+
+                    match result {
+                        Err(err) => {
+                            error_sender.send(err).expect("Could not send error");
+                        }
+                        Ok(attachment) => {
+                            statistics.add_document_download(1);
+
+                            sender
+                                .send((
+                                    PackageContentId::Document {
+                                        source_id,
+                                        comment_id,
+                                        key,
+                                        extension,
+                                    },
+                                    attachment,
+                                ))
+                                .expect("could not send attachment");
+                        }
+                    }
+                });
+            });
+    });
+
+    if let Ok(error) = error_receiver.try_recv() {
+        return Err(anyhow!("Failed to upload document {}", error));
+    };
+
+    drop(document_sender);
+
+    document_receiver
+        .iter()
+        .try_for_each(|(content_id, content)| -> Result<()> {
+            package_writer
+                .write_bytes(content_id, &content)
+                .context("Failed to write document bytes")?;
+            statistics.add_document_write(1);
+            Ok(())
+        })?;
+
+    Ok(())
+}
+
+fn get_comment_count(dataset: &Dataset, client: &Client) -> Result<u64> {
+    let total_comments = *client
+        .get_dataset_statistics(&dataset.full_name(), &Default::default())
+        .context("Failed to get dataset statistics")?
+        .num_comments as u64;
+    Ok(total_comments)
+}
+
+pub fn run(args: &DownloadPackageArgs, client: &Client, pool: &mut Pool) -> Result<()> {
+    let DownloadPackageArgs {
+        project,
+        file,
+        overwrite,
+        batch_size,
+        max_attachment_memory_mb,
+    } = args;
+    // Delete output file if overwriting
+    if *overwrite && file.is_file() {
+        remove_file(file).context("Failed to remove existing file")?;
+    }
+
+    // Get dataset, statistics and progres bar
+    let dataset = get_project(project, client).context("Failed to get project")?;
+    let total_comments =
+        get_comment_count(&dataset, client).context("Failed to get comment count")?;
+
+    let statistics = Arc::new(Statistics::new());
+    let _progress_bar = get_progress_bar(total_comments, &statistics);
+
+    // Write dataset
+    let mut package_writer =
+        PackageWriter::new(file.into()).context("Failed to create new package writer")?;
+    package_writer
+        .write_dataset(&dataset)
+        .context("Failed to write dataset")?;
+
+    // Package each source
+    for source_id in &dataset.source_ids {
+        let source = client
+            .get_source(source_id.clone())
+            .context("Failed to get source")?;
+
+        package_writer
+            .write_source(&source)
+            .context("Failed to write source")?;
+
+        package_source_contents(
+            &dataset.full_name(),
+            source_id,
+            *batch_size,
+            &mut package_writer,
+            client,
+            &statistics,
+            max_attachment_memory_mb,
+            pool,
+        )
+        .context("Failed to package source context")?;
+    }
+
+    package_writer
+        .finish()
+        .context("Failed to finish package writer")?;
+    log::info!("Package exported");
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct Statistics {
+    comments: AtomicUsize,
+    document_downloads: AtomicUsize,
+    document_writes: AtomicUsize,
+    annotations: AtomicUsize,
+}
+
+impl Statistics {
+    fn new() -> Self {
+        Self {
+            comments: AtomicUsize::new(0),
+            annotations: AtomicUsize::new(0),
+            document_downloads: AtomicUsize::new(0),
+            document_writes: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline]
+    fn add_comments(&self, num: usize) {
+        self.comments.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_document_download(&self, num: usize) {
+        self.document_downloads.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_document_write(&self, num: usize) {
+        self.document_writes.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_annotations(&self, num: usize) {
+        self.annotations.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn num_comments(&self) -> usize {
+        self.comments.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn num_document_downloaded(&self) -> usize {
+        self.document_downloads.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn num_document_writes(&self) -> usize {
+        self.document_writes.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn num_annotations(&self) -> usize {
+        self.annotations.load(Ordering::SeqCst)
+    }
+}
+fn get_progress_bar(total_comments: u64, statistics: &Arc<Statistics>) -> Progress {
+    Progress::new(
+        move |statistics| {
+            let num_comments = statistics.num_comments();
+            let num_docs_downloaded = statistics.num_document_downloaded();
+            let num_annotations = statistics.num_annotations();
+            let num_docs_written = statistics.num_document_writes();
+            (
+                (num_comments + num_docs_downloaded + num_docs_written) as u64,
+                format!(
+                    "{} {} {} {} {} {} {} {}",
+                    num_comments.to_string().bold(),
+                    "comments".dimmed(),
+                    num_annotations.to_string().bold(),
+                    "annotations".dimmed(),
+                    num_docs_downloaded.to_string().bold(),
+                    "docs downloaded".dimmed(),
+                    num_docs_written.to_string().bold(),
+                    "docs written".dimmed(),
+                ),
+            )
+        },
+        statistics,
+        Some(total_comments),
+        crate::progress::Options { bytes_units: false },
+    )
+}

--- a/cli/src/commands/package/mod.rs
+++ b/cli/src/commands/package/mod.rs
@@ -1,0 +1,345 @@
+use anyhow::{Context, Result};
+use download::DownloadPackageArgs;
+use itertools::Itertools;
+use reinfer_client::{
+    AnnotatedComment, Client, CommentId, Dataset, DatasetId, NewAnnotatedComment, Source, SourceId,
+};
+use scoped_threadpool::Pool;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    fs::{File, OpenOptions},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+use structopt::StructOpt;
+use upload::UploadPackageArgs;
+use zip::{write::SimpleFileOptions, ZipArchive, ZipWriter};
+
+mod download;
+mod upload;
+
+#[derive(Debug, StructOpt)]
+pub enum PackageArgs {
+    #[structopt(name = "download")]
+    /// Download a package
+    Download(DownloadPackageArgs),
+
+    #[structopt(name = "upload")]
+    /// Upload a package
+    Upload(UploadPackageArgs),
+}
+
+pub struct CommentBatchKey(usize);
+#[derive(Clone)]
+pub struct AttachmentKey(usize);
+
+pub fn run(args: &PackageArgs, client: Client, pool: &mut Pool) -> Result<()> {
+    match args {
+        PackageArgs::Download(args) => download::run(args, &client, pool),
+        PackageArgs::Upload(args) => upload::run(args, &client, pool),
+    }
+}
+
+pub enum PackageContentId<'a> {
+    Dataset {
+        dataset_id: &'a DatasetId,
+    },
+    Source {
+        source_id: &'a SourceId,
+    },
+    CommentBatch {
+        key: CommentBatchKey,
+        source_id: &'a SourceId,
+    },
+    Document {
+        source_id: &'a SourceId,
+        comment_id: &'a CommentId,
+        key: &'a AttachmentKey,
+        extension: Option<String>,
+    },
+}
+
+static DATASET_POSTFIX_AND_EXTENSION: &str = "dataset.json";
+static SOURCE_POSTFIX_AND_EXTENSION: &str = "source.json";
+static COMMENTS_POSTFIX_AND_EXTENSION: &str = "comments.json";
+static DATASETS_FOLDER_NAME: &str = "datasets";
+static SOURCES_FOLDER_NAME: &str = "sources";
+static COMMENTS_FOLDER_NAME: &str = "comments";
+static DOCUMENTS_FOLDER_NAME: &str = "documents";
+
+impl PackageContentId<'_> {
+    fn filename(&self) -> String {
+        match self {
+            PackageContentId::Dataset { dataset_id } => {
+                format!(
+                    "{DATASETS_FOLDER_NAME}/{0}.{DATASET_POSTFIX_AND_EXTENSION}",
+                    dataset_id.0
+                )
+            }
+            PackageContentId::Source { source_id } => {
+                format!(
+                    "{SOURCES_FOLDER_NAME}/{0}.{SOURCE_POSTFIX_AND_EXTENSION}",
+                    source_id.0
+                )
+            }
+            PackageContentId::CommentBatch { key, source_id } => {
+                format!(
+                    "{COMMENTS_FOLDER_NAME}/{0}.{1}.{COMMENTS_POSTFIX_AND_EXTENSION}",
+                    source_id.0, key.0
+                )
+            }
+            PackageContentId::Document {
+                source_id,
+                comment_id,
+                extension,
+                key,
+            } => {
+                if let Some(extension) = extension {
+                    format!(
+                        "{DOCUMENTS_FOLDER_NAME}/{0}.{1}.{2}.document.{3}",
+                        source_id.0, comment_id.0, key.0, extension
+                    )
+                } else {
+                    format!("{0}.{1}.{2}.document", source_id.0, comment_id.0, key.0)
+                }
+            }
+        }
+    }
+
+    fn friendly_name(&self) -> String {
+        match self {
+            PackageContentId::Dataset { dataset_id } => format!("dataset {}", dataset_id.0),
+            PackageContentId::Source { source_id } => format!("source {}", source_id.0),
+            PackageContentId::CommentBatch { key, source_id } => {
+                format!("comment batch {0} for source {1}", key.0, source_id.0)
+            }
+            PackageContentId::Document {
+                source_id,
+                comment_id,
+                key,
+                extension,
+            } => {
+                let extension_part = if let Some(extension) = extension {
+                    format!("{0} ", extension)
+                } else {
+                    String::new()
+                };
+
+                format!(
+                    "{0}attachment for comment {1}, in source {2} with key {3}",
+                    extension_part, comment_id.0, source_id.0, key.0
+                )
+            }
+        }
+    }
+}
+
+pub struct PackageWriter {
+    writer: ZipWriter<File>,
+}
+
+pub struct Package {
+    archive: ZipArchive<File>,
+}
+
+impl Package {
+    fn new(path: &PathBuf) -> Result<Self> {
+        let file = File::open(path)?;
+        let archive = ZipArchive::new(file)?;
+
+        Ok(Self { archive })
+    }
+
+    pub fn read_document(
+        &mut self,
+        source_id: &SourceId,
+        comment_id: &CommentId,
+        key: &AttachmentKey,
+        extension: Option<String>,
+    ) -> Result<Vec<u8>> {
+        let content_id = PackageContentId::Document {
+            source_id,
+            comment_id,
+            key,
+            extension,
+        };
+
+        self.read_bytes(content_id)
+    }
+
+    pub fn read_bytes(&mut self, content_id: PackageContentId) -> Result<Vec<u8>> {
+        let mut contents = Vec::new();
+        let mut file = self.archive.by_name(&content_id.filename())?;
+
+        file.read_to_end(&mut contents)?;
+        Ok(contents)
+    }
+
+    fn get_filenames_with_postfix_and_extension(&self, postfix: &str) -> Vec<String> {
+        self.archive
+            .file_names()
+            .filter(|name| name.ends_with(postfix))
+            .map(str::to_string)
+            .collect()
+    }
+
+    pub fn get_source_by_id(&mut self, source_id: &SourceId) -> Result<Source> {
+        self.read_json_content_by_id(PackageContentId::Source { source_id })
+    }
+
+    pub fn get_comment_batch(
+        &mut self,
+        source_id: &SourceId,
+        key: CommentBatchKey,
+    ) -> Result<Vec<NewAnnotatedComment>> {
+        let content_id = PackageContentId::CommentBatch { key, source_id };
+
+        self.read_jsonl_content_by_id(content_id)
+    }
+
+    pub fn get_comment_batch_count_for_source(&mut self, source_id: &SourceId) -> usize {
+        self.get_filenames_with_postfix_and_extension(COMMENTS_POSTFIX_AND_EXTENSION)
+            .iter()
+            .filter(|filename| {
+                let path = Path::new(filename);
+                path.file_name()
+                    .is_some_and(|name| name.to_string_lossy().starts_with(&source_id.0))
+            })
+            .count()
+    }
+
+    pub fn get_document_count(&mut self) -> usize {
+        self.archive
+            .file_names()
+            .filter(|name| {
+                let path = Path::new(name);
+                path.parent()
+                    .is_some_and(|folder| folder.to_string_lossy() == DOCUMENTS_FOLDER_NAME)
+            })
+            .count()
+    }
+
+    pub fn datasets(&mut self) -> Result<Vec<Dataset>> {
+        let dataset_filenames =
+            self.get_filenames_with_postfix_and_extension(DATASET_POSTFIX_AND_EXTENSION);
+
+        dataset_filenames
+            .iter()
+            .map(|filename| self.read_json_content_by_name(filename))
+            .try_collect()
+    }
+
+    fn read_string_content_by_name(&mut self, filename: &str) -> Result<String> {
+        let mut file = self.archive.by_name(filename)?;
+
+        let mut buf = String::new();
+        file.read_to_string(&mut buf)?;
+        Ok(buf)
+    }
+
+    fn read_json_content_by_name<T>(&mut self, filename: &str) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let string = self.read_string_content_by_name(filename)?;
+
+        Ok(serde_json::from_str(&string)?)
+    }
+
+    fn read_jsonl_content_by_id<T>(&mut self, content: PackageContentId) -> Result<Vec<T>>
+    where
+        T: DeserializeOwned,
+    {
+        let string = self
+            .read_string_content_by_name(&content.filename())
+            .context(format!(
+                "Package does not contain a valid jsonl record for {}",
+                content.friendly_name()
+            ))?;
+
+        string
+            .lines()
+            .map(|line| -> Result<T> {
+                serde_json::from_str::<T>(line).map_err(anyhow::Error::msg)
+            })
+            .try_collect()
+    }
+
+    fn read_json_content_by_id<T>(&mut self, content: PackageContentId) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        self.read_json_content_by_name(&content.filename())
+            .context(format!(
+                "Package does not contain a valid json record for {}",
+                content.friendly_name()
+            ))
+    }
+}
+
+impl PackageWriter {
+    pub fn new(path: PathBuf) -> Result<Self> {
+        let file = OpenOptions::new().write(true).create_new(true).open(path)?;
+        let writer = ZipWriter::new(file);
+        Ok(Self { writer })
+    }
+
+    pub fn write_dataset(&mut self, dataset: &Dataset) -> Result<()> {
+        let dataset_id = &dataset.id;
+
+        self.write_json(PackageContentId::Dataset { dataset_id }, dataset)
+    }
+
+    pub fn write_source(&mut self, source: &Source) -> Result<()> {
+        let source_id = &source.id;
+        self.write_json(PackageContentId::Source { source_id }, source)
+    }
+
+    pub fn write_comment_batch(
+        &mut self,
+        source_id: &SourceId,
+        key: CommentBatchKey,
+        comments: &[AnnotatedComment],
+    ) -> Result<()> {
+        self.write_jsonl(PackageContentId::CommentBatch { key, source_id }, comments)
+    }
+
+    pub fn write_bytes(&mut self, content_id: PackageContentId, content: &[u8]) -> Result<()> {
+        self.writer
+            .start_file_from_path(content_id.filename(), SimpleFileOptions::default())?;
+        self.writer.write_all(content).map_err(anyhow::Error::msg)
+    }
+
+    fn write_jsonl<T>(&mut self, content_id: PackageContentId, content: &[T]) -> Result<()>
+    where
+        T: Serialize,
+    {
+        self.writer
+            .start_file_from_path(content_id.filename(), SimpleFileOptions::default())?;
+
+        content.iter().try_for_each(|item| -> Result<()> {
+            let json = serde_json::to_string(item)?;
+
+            self.writer
+                .write_all(format!("{json}\n").as_bytes())
+                .map_err(anyhow::Error::msg)
+        })
+    }
+
+    fn write_json<T>(&mut self, content_id: PackageContentId, content: &T) -> Result<()>
+    where
+        T: Serialize,
+    {
+        self.writer
+            .start_file_from_path(content_id.filename(), SimpleFileOptions::default())?;
+        let json_content = serde_json::to_string_pretty(content)?;
+
+        self.writer.write_all(json_content.as_bytes())?;
+        Ok(())
+    }
+
+    fn finish(self) -> Result<()> {
+        self.writer.finish()?;
+        Ok(())
+    }
+}

--- a/cli/src/commands/package/upload.rs
+++ b/cli/src/commands/package/upload.rs
@@ -1,4 +1,3 @@
-use chrono::Utc;
 use colored::Colorize;
 use itertools::Itertools;
 use std::{
@@ -11,7 +10,7 @@ use std::{
         Arc,
     },
     thread::sleep,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -44,13 +43,13 @@ pub struct UploadPackageArgs {
 
     #[structopt(long = "dataset-creation-timeout", default_value = "30")]
     /// Maximum number of seconds to wait for dataset to be created
-    dataset_creation_timeout: i64,
+    dataset_creation_timeout: u64,
 }
 
-fn wait_for_dataset_to_exist(dataset: &Dataset, client: &Client, timeout_s: i64) -> Result<()> {
-    let start_time = Utc::now();
+fn wait_for_dataset_to_exist(dataset: &Dataset, client: &Client, timeout_s: u64) -> Result<()> {
+    let start_time = Instant::now();
 
-    while (start_time - Utc::now()).num_seconds() <= timeout_s {
+    while (start_time - Instant::now()).as_secs() <= timeout_s {
         let datasets = client.get_datasets()?;
 
         let dataset_exists = datasets
@@ -72,7 +71,7 @@ fn create_dataset(
     name: DatasetName,
     label_defs: Vec<LabelDef>,
     client: &Client,
-    timeout_s: i64,
+    timeout_s: u64,
 ) -> Result<Dataset> {
     let mut new_label_defs = Vec::new();
 

--- a/cli/src/commands/package/upload.rs
+++ b/cli/src/commands/package/upload.rs
@@ -1,0 +1,515 @@
+use chrono::Utc;
+use colored::Colorize;
+use itertools::Itertools;
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc::channel,
+        Arc,
+    },
+    thread::sleep,
+    time::Duration,
+};
+
+use anyhow::{anyhow, Context, Result};
+use reinfer_client::{
+    resources::dataset::IxpDatasetNew, Client, CommentUid, Dataset, DatasetFullName, DatasetName,
+    LabelDef, NewAnnotatedComment, NewLabelDef, Source, SourceId, SourceKind,
+    DEFAULT_LABEL_GROUP_NAME,
+};
+use scoped_threadpool::Pool;
+use structopt::StructOpt;
+
+use crate::{
+    commands::package::{AttachmentKey, CommentBatchKey, Package},
+    progress::Progress,
+};
+
+#[derive(Debug, StructOpt)]
+pub struct UploadPackageArgs {
+    /// Path of the package to upload
+    #[structopt(parse(from_os_str))]
+    file: PathBuf,
+
+    #[structopt(long = "resume-on-error")]
+    /// Whether to attempt to resume processing on error
+    resume_on_error: bool,
+
+    #[structopt(long = "max-attachment-memory-mb", default_value = "256")]
+    /// Maximum number of mb to use to store attachments in memory
+    max_attachment_memory_mb: u64,
+
+    #[structopt(long = "dataset-creation-timeout", default_value = "30")]
+    /// Maximum number of seconds to wait for dataset to be created
+    dataset_creation_timeout: i64,
+}
+
+fn wait_for_dataset_to_exist(dataset: &Dataset, client: &Client, timeout_s: i64) -> Result<()> {
+    let start_time = Utc::now();
+
+    while (start_time - Utc::now()).num_seconds() <= timeout_s {
+        let datasets = client.get_datasets()?;
+
+        let dataset_exists = datasets
+            .iter()
+            .map(|dataset| dataset.full_name())
+            .contains(&dataset.full_name());
+
+        if dataset_exists {
+            return Ok(());
+        } else {
+            sleep(Duration::from_millis(500));
+        }
+    }
+
+    Err(anyhow!("Timeout waiting for dataset to be created"))
+}
+
+fn create_dataset(
+    name: DatasetName,
+    label_defs: Vec<LabelDef>,
+    client: &Client,
+    timeout_s: i64,
+) -> Result<Dataset> {
+    let mut new_label_defs = Vec::new();
+
+    label_defs.iter().try_for_each(|label| -> Result<()> {
+        new_label_defs.push(NewLabelDef::try_from(label)?);
+        Ok(())
+    })?;
+
+    let dataset = client
+        .create_ixp_dataset(IxpDatasetNew { name })
+        .context("Error when creating dataset")
+        .map_err(anyhow::Error::msg)?;
+
+    wait_for_dataset_to_exist(&dataset, client, timeout_s)?;
+
+    client
+        .create_label_defs_bulk(
+            &dataset.full_name(),
+            DEFAULT_LABEL_GROUP_NAME.clone(),
+            new_label_defs,
+        )
+        .context("Error when creating label defs")?;
+    Ok(dataset)
+}
+
+pub struct IxpDatasetSources {
+    runtime: Source,
+    design_time: Source,
+}
+
+enum SourceProvider<'a> {
+    Packaged(&'a mut Package),
+    Remote(&'a Client),
+}
+
+impl SourceProvider<'_> {
+    fn get_source(&mut self, source_id: &SourceId) -> Result<Source> {
+        match self {
+            Self::Packaged(package) => package.get_source_by_id(source_id),
+            Self::Remote(client) => client
+                .get_source(source_id.clone())
+                .map_err(anyhow::Error::msg),
+        }
+    }
+}
+
+impl Display for SourceProvider<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Packaged(_) => "packaged",
+                Self::Remote(_) => "remote",
+            }
+        )
+    }
+}
+
+fn get_ixp_source(dataset: &Dataset, mut provider: SourceProvider) -> Result<IxpDatasetSources> {
+    let mut source_by_kind: HashMap<SourceKind, Source> = HashMap::new();
+    dataset
+        .source_ids
+        .iter()
+        .try_for_each(|source_id| -> Result<()> {
+            let source = provider
+                .get_source(source_id)
+                .context("Could not get source")?;
+            if source_by_kind.contains_key(&source.kind) {
+                return Err(anyhow!("Duplicate source kind found in packaged dataset"));
+            }
+
+            source_by_kind.insert(source.kind.clone(), source.clone());
+            Ok(())
+        })?;
+
+    let runtime = source_by_kind
+        .get(&SourceKind::IxpRuntime)
+        .context(anyhow!(
+            "Could not find runtime source for {0} dataset {1}",
+            provider,
+            dataset.id.0
+        ))?
+        .clone();
+
+    let design_time = source_by_kind
+        .get(&SourceKind::IxpDesignTime)
+        .context(anyhow!(
+            "Could not find design time source for {0} dataset {1}",
+            provider,
+            dataset.id.0
+        ))?
+        .clone();
+
+    Ok(IxpDatasetSources {
+        runtime,
+        design_time,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn unpack_ixp_source(
+    old_source: &Source,
+    new_source: &Source,
+    new_dataset: &Dataset,
+    package: &mut Package,
+    client: &Client,
+    pool: &mut Pool,
+    resume_on_error: bool,
+    statistics: &Statistics,
+    max_attachment_memory_mb: &u64,
+) -> Result<()> {
+    let batch_count = package.get_comment_batch_count_for_source(&old_source.id);
+
+    let mut documents = Vec::new();
+    for idx in 0..batch_count {
+        let batch = package
+            .get_comment_batch(&old_source.id, CommentBatchKey(idx))
+            .context("Could not get comment batch")?;
+
+        batch.iter().try_for_each(|comment| -> Result<()> {
+            comment.comment.attachments.iter().enumerate().try_for_each(
+                |(idx, attachment)| -> Result<()> {
+                    let read_result = package.read_document(
+                        &old_source.id,
+                        &comment.comment.id,
+                        &AttachmentKey(idx),
+                        attachment.extension(),
+                    );
+
+                    match read_result {
+                        Ok(result) => {
+                            statistics.add_document_reads(1);
+
+                            documents.push(AnnotationWithContent {
+                                comment: comment.clone(),
+                                content: result,
+                                size: attachment.size as usize,
+                                file_name: attachment.name.clone(),
+                            });
+
+                            if should_upload_batch(&documents, max_attachment_memory_mb) {
+                                upload_batch(
+                                    &documents,
+                                    client,
+                                    &new_source.id,
+                                    &new_dataset.full_name(),
+                                    resume_on_error,
+                                    statistics,
+                                    pool,
+                                )
+                                .context("Failed to upload batch")?;
+                                documents.clear();
+                            }
+                            Ok(())
+                        }
+                        Err(_) if resume_on_error => {
+                            statistics.add_failed_document_reads(1);
+                            Ok(())
+                        }
+                        Err(err) => Err(err),
+                    }
+                },
+            )
+        })?;
+    }
+    upload_batch(
+        &documents,
+        client,
+        &new_source.id,
+        &new_dataset.full_name(),
+        resume_on_error,
+        statistics,
+        pool,
+    )
+}
+
+fn should_upload_batch(batch: &[AnnotationWithContent], max_attachment_memory_mb: &u64) -> bool {
+    batch
+        .iter()
+        .map(|attachment| attachment.size as u64)
+        .sum::<u64>()
+        / 1_000_000
+        >= *max_attachment_memory_mb
+}
+
+struct AnnotationWithContent {
+    comment: NewAnnotatedComment,
+    file_name: String,
+    content: Vec<u8>,
+    size: usize,
+}
+
+fn upload_batch(
+    batch: &Vec<AnnotationWithContent>,
+    client: &Client,
+    source_id: &SourceId,
+    dataset_name: &DatasetFullName,
+    resume_on_error: bool,
+    statistics: &Statistics,
+    pool: &mut Pool,
+) -> Result<()> {
+    let (error_sender, error_receiver) = channel();
+
+    pool.scoped(|scope| {
+        for item in batch {
+            let error_sender = error_sender.clone();
+            scope.execute(move || {
+                let upload_result = client
+                    .upload_ixp_document(source_id, item.file_name.clone(), item.content.clone())
+                    .map_err(anyhow::Error::msg);
+
+                match upload_result {
+                    Ok(new_comment_id) => {
+                        statistics.add_document_uploads(1);
+
+                        let comment_uid =
+                            CommentUid(format!("{}.{}", source_id.0, new_comment_id.0));
+
+                        if item.comment.has_annotations() {
+                            let labelling_result = client.update_labelling(
+                                dataset_name,
+                                &comment_uid,
+                                None,
+                                item.comment.entities.as_ref(),
+                                item.comment.moon_forms.as_deref(),
+                            );
+
+                            match labelling_result {
+                                Ok(_) => {
+                                    statistics.add_annotation(1);
+                                }
+                                Err(_) if resume_on_error => {
+                                    statistics.add_failed_annotations(1);
+                                }
+                                Err(err) => error_sender
+                                    .send(anyhow::Error::msg(err))
+                                    .expect("Could not send error"),
+                            }
+                        }
+                    }
+
+                    Err(_) if resume_on_error => {
+                        statistics.add_failed_uploads(1);
+                    }
+
+                    Err(err) => error_sender.send(err).expect("Could not send error"),
+                }
+            })
+        }
+    });
+
+    drop(error_sender);
+
+    if let Ok(error) = error_receiver.try_recv() {
+        return Err(anyhow!("Failed to upload document {}", error));
+    };
+
+    Ok(())
+}
+
+pub fn run(args: &UploadPackageArgs, client: &Client, pool: &mut Pool) -> Result<()> {
+    let UploadPackageArgs {
+        file,
+        resume_on_error,
+        max_attachment_memory_mb,
+        dataset_creation_timeout,
+    } = args;
+
+    let mut package =
+        Package::new(file).context("Failed to read package, check path is correct.")?;
+
+    let statistics = Arc::new(Statistics::new());
+    let total_documents = package.get_document_count();
+
+    let _progress_bar = get_progress_bar(total_documents as u64, &statistics);
+
+    for dataset in package
+        .datasets()
+        .context("Could not get package datastes")?
+    {
+        let packaged_sources = get_ixp_source(&dataset, SourceProvider::Packaged(&mut package))
+            .context("Could not get ixp source from package")?;
+
+        let new_dataset = create_dataset(
+            dataset.name,
+            dataset.label_defs,
+            client,
+            *dataset_creation_timeout,
+        )
+        .context("Could not create dataset")?;
+
+        let new_sources = get_ixp_source(&new_dataset, SourceProvider::Remote(client))
+            .context("Could not get ixp source via api")?;
+
+        for (packaged, new) in [
+            (&packaged_sources.design_time, &new_sources.design_time),
+            (&packaged_sources.runtime, &new_sources.runtime),
+        ] {
+            unpack_ixp_source(
+                packaged,
+                new,
+                &new_dataset,
+                &mut package,
+                client,
+                pool,
+                *resume_on_error,
+                &statistics,
+                max_attachment_memory_mb,
+            )
+            .context("Failed to unpack ixp source")?;
+        }
+    }
+
+    log::info!("Package uploaded.");
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct Statistics {
+    document_reads: AtomicUsize,
+    document_uploads: AtomicUsize,
+    annotations: AtomicUsize,
+    failed_annotations: AtomicUsize,
+    failed_reads: AtomicUsize,
+    failed_uploads: AtomicUsize,
+}
+
+impl Statistics {
+    fn new() -> Self {
+        Self {
+            annotations: AtomicUsize::new(0),
+            document_uploads: AtomicUsize::new(0),
+            document_reads: AtomicUsize::new(0),
+            failed_annotations: AtomicUsize::new(0),
+            failed_reads: AtomicUsize::new(0),
+            failed_uploads: AtomicUsize::new(0),
+        }
+    }
+
+    #[inline]
+    fn add_annotation(&self, num: usize) {
+        self.annotations.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_failed_annotations(&self, num: usize) {
+        self.failed_annotations.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_failed_uploads(&self, num: usize) {
+        self.failed_uploads.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_document_uploads(&self, num: usize) {
+        self.document_uploads.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn add_document_reads(&self, num: usize) {
+        self.document_reads.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn num_document_uploads(&self) -> usize {
+        self.document_uploads.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn num_document_reads(&self) -> usize {
+        self.document_reads.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn num_annotations(&self) -> usize {
+        self.annotations.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn add_failed_document_reads(&self, num: usize) {
+        self.failed_reads.fetch_add(num, Ordering::SeqCst);
+    }
+
+    #[inline]
+    fn num_failed_annotations(&self) -> usize {
+        self.failed_annotations.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn num_failed_reads(&self) -> usize {
+        self.failed_reads.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn num_failed_uploads(&self) -> usize {
+        self.failed_uploads.load(Ordering::SeqCst)
+    }
+}
+
+fn get_progress_bar(total_comments: u64, statistics: &Arc<Statistics>) -> Progress {
+    Progress::new(
+        move |statistics| {
+            let num_docs_read = statistics.num_document_reads();
+            let num_docs_uploaded = statistics.num_document_uploads();
+            let num_annotations = statistics.num_annotations();
+            let num_failed_annotations = statistics.num_failed_annotations();
+            let num_failed_reads = statistics.num_failed_reads();
+            let num_failed_uploads = statistics.num_failed_uploads();
+
+            fn get_failed_part(val: usize, name: &str) -> String {
+                if val > 0 {
+                    format!(" {} {}", val.to_string().bold(), name.dimmed())
+                } else {
+                    String::new()
+                }
+            }
+
+            (
+                ((num_docs_uploaded + num_docs_read) / 2) as u64,
+                format!(
+                    "{} {} {} {} {} {}{}{}{}",
+                    num_docs_read.to_string().bold(),
+                    "docs read".dimmed(),
+                    num_docs_uploaded.to_string().bold(),
+                    "docs uploaded".dimmed(),
+                    num_annotations.to_string().bold(),
+                    "annotations".dimmed(),
+                    get_failed_part(num_failed_reads, "failed reads"),
+                    get_failed_part(num_failed_uploads, "failed uploads"),
+                    get_failed_part(num_failed_annotations, "failed annotations")
+                ),
+            )
+        },
+        statistics,
+        Some(total_comments),
+        crate::progress::Options { bytes_units: false },
+    )
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,10 +8,12 @@ mod thousands;
 mod utils;
 
 use anyhow::{anyhow, Context, Result};
+use commands::package;
 use log::{error, warn};
+use once_cell::sync::Lazy;
 use reinfer_client::{
     retry::{RetryConfig, RetryStrategy},
-    Client, Config as ClientConfig, Token, DEFAULT_ENDPOINT,
+    Client, Config as ClientConfig, ProjectName, Token, DEFAULT_ENDPOINT,
 };
 use scoped_threadpool::Pool;
 use std::{env, fs, io, path::PathBuf, process};
@@ -25,6 +27,9 @@ use crate::{
 };
 
 const NUM_THREADS_ENV_VARIABLE_NAME: &str = "REINFER_CLI_NUM_THREADS";
+
+static DEFAULT_PROJECT_NAME: Lazy<ProjectName> =
+    Lazy::new(|| ProjectName("DefaultProject".to_string()));
 
 fn run(args: Args) -> Result<()> {
     let config_path = find_configuration(&args)?;
@@ -76,6 +81,10 @@ fn run(args: Args) -> Result<()> {
         }
         Command::Parse { parse_args } => {
             parse::run(parse_args, client_from_args(&args, &config)?, &mut pool)
+        }
+
+        Command::Package { package_args } => {
+            package::run(package_args, client_from_args(&args, &config)?, &mut pool)
         }
     }
 }

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -269,7 +269,7 @@ fn test_create_update_dataset_custom() {
                     moon_form: Some(vec![MoonFormFieldDef {
                         name: "luna".to_owned(),
                         kind: "ent".to_owned(),
-                        instructions: None,
+                        instructions: Some(String::new()),
                     }]),
                 },
             ],

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -242,7 +242,7 @@ fn test_create_update_dataset_custom() {
                 moon_form: Some(vec![MoonFormFieldDef {
                     name: "luna".to_owned(),
                     kind: "ent".to_owned(),
-                    instructions: None,
+                    instructions: Some(String::new()),
                 }]),
             },
         ],

--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -242,6 +242,7 @@ fn test_create_update_dataset_custom() {
                 moon_form: Some(vec![MoonFormFieldDef {
                     name: "luna".to_owned(),
                     kind: "ent".to_owned(),
+                    instructions: None,
                 }]),
             },
         ],
@@ -268,6 +269,7 @@ fn test_create_update_dataset_custom() {
                     moon_form: Some(vec![MoonFormFieldDef {
                         name: "luna".to_owned(),
                         kind: "ent".to_owned(),
+                        instructions: None,
                     }]),
                 },
             ],


### PR DESCRIPTION
Adds `re package download` and `re package upload` where a `package` is a zip containing all the dependencies for an ixp project (dataset def, source def, annotations, comments, documents etc...) allowing users to move around stuff with minimal fuss. 

One day I'll expand the scope of this to include CM projects. 