### PR TITLE
feat(cli): allow users to specify project name when downloading packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Allow users to specify projects when downloading packages
+
 # v0.37.2
 - Fix a bug where updating a source would result in it's bucket becoming detached 
 

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -130,6 +130,12 @@ impl FromStr for FullName {
     }
 }
 
+impl Display for FullName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TimeResolution {


### PR DESCRIPTION
Allows users to specify the project name when downloading packages for legacy ixp projects 