### PR TITLE
(chore) Update Cargo.toml use repository instead of homepage

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "reinfer-cli"
 version = "0.38.0"
 description = "Command line interface for Re:infer, the conversational data intelligence platform"
-homepage = "https://github.com/reinfer/cli"
+repository = "https://github.com/reinfer/cli"
 readme = "README.md"
 authors = ["reinfer Ltd. <eng@reinfer.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/91