### PR TITLE
fix(cli): round trip entity defs in ixp cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Fix issue where entity definitons were not round tripped for ixp packages 
+
 # v0.38.2
 - Round trip model config on datasets
 

--- a/api/src/resources/dataset.rs
+++ b/api/src/resources/dataset.rs
@@ -515,6 +515,9 @@ pub struct UpdateDataset<'request> {
 
     #[serde(rename = "_model_config", skip_serializing_if = "Option::is_none")]
     pub model_config: Option<ModelConfig>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub entity_defs: Vec<NewEntityDef>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/api/src/resources/entity_def.rs
+++ b/api/src/resources/entity_def.rs
@@ -19,6 +19,8 @@ pub struct EntityDef {
     pub entity_def_flags: Vec<EntityDefFlag>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rules: Option<EntityDefRuleSet>,
+    #[serde(default)]
+    pub instructions: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -67,6 +69,8 @@ pub struct NewEntityDef {
     pub entity_def_flags: Vec<EntityDefFlag>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rules: Option<EntityDefRuleSet>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/cli/src/commands/package/upload.rs
+++ b/cli/src/commands/package/upload.rs
@@ -17,7 +17,8 @@ use anyhow::{anyhow, Context, Result};
 use reinfer_client::{
     resources::dataset::{IxpDatasetNew, ModelConfig},
     Client, CommentUid, Dataset, DatasetFullName, DatasetName, LabelDef, NewAnnotatedComment,
-    NewLabelDef, Source, SourceId, SourceKind, UpdateDataset, DEFAULT_LABEL_GROUP_NAME,
+    NewEntityDef, NewLabelDef, Source, SourceId, SourceKind, UpdateDataset,
+    DEFAULT_LABEL_GROUP_NAME,
 };
 use scoped_threadpool::Pool;
 use structopt::StructOpt;
@@ -81,6 +82,7 @@ fn create_dataset(
     client: &Client,
     timeout_s: u64,
     model_config: ModelConfig,
+    entity_defs: Vec<NewEntityDef>,
 ) -> Result<Dataset> {
     let mut new_label_defs = Vec::new();
 
@@ -100,6 +102,7 @@ fn create_dataset(
             source_ids: None,
             title: None,
             description: None,
+            entity_defs,
         },
     )?;
 
@@ -384,6 +387,19 @@ pub fn run(args: &UploadPackageArgs, client: &Client, pool: &mut Pool) -> Result
             client,
             *dataset_creation_timeout,
             dataset.model_config,
+            dataset
+                .entity_defs
+                .into_iter()
+                .map(|def| NewEntityDef {
+                    entity_def_flags: def.entity_def_flags,
+                    inherits_from: def.inherits_from,
+                    name: def.name,
+                    rules: def.rules,
+                    title: def.title,
+                    trainable: def.trainable,
+                    instructions: def.instructions,
+                })
+                .collect(),
         )
         .context("Could not create dataset")?;
 

--- a/cli/src/commands/update/dataset.rs
+++ b/cli/src/commands/update/dataset.rs
@@ -59,6 +59,7 @@ pub fn update(client: &Client, args: &UpdateDatasetArgs, printer: &Printer) -> R
                 title: title.as_deref(),
                 description: description.as_deref(),
                 model_config: None,
+                entity_defs: Vec::new(),
             },
         )
         .context("Operation to update a dataset has failed.")?;


### PR DESCRIPTION
Fixes an issue where entity definitions were not round tripped in ixp ucd packages 