### PR TITLE
fix(cli): correct package download progress bar math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - Support `gpt_5_1_2025_11_13`, `gpt_5_4_2026_03_05`, `gemini_2_5_pro`, and `gemini_3_1_pro_preview` model versions
 - Fix downloaded packages placing extension-less documents at the package root instead of in the `documents/` folder
+- Fix `re package download` progress bar showing more progress than the total when the dataset's comment count is approximate
 
 # v0.39.0
 - Allow `re get comments --reviewed-only` to be combined with dataset filters

--- a/cli/src/commands/package/download.rs
+++ b/cli/src/commands/package/download.rs
@@ -598,7 +598,7 @@ fn get_ixp_progress_bar(total_comments: u64, statistics: &Arc<Statistics>) -> Pr
             let num_annotations = statistics.num_annotations();
             let num_docs_written = statistics.num_document_writes();
             (
-                ((num_comments + num_docs_downloaded + num_docs_written) / 3) as u64,
+                (num_comments + num_docs_downloaded + num_docs_written) as u64,
                 format!(
                     "{} {} {} {} {} {} {} {}",
                     num_comments.to_string().bold(),
@@ -613,7 +613,7 @@ fn get_ixp_progress_bar(total_comments: u64, statistics: &Arc<Statistics>) -> Pr
             )
         },
         statistics,
-        Some(total_comments),
+        Some(total_comments * 3),
         crate::progress::Options { bytes_units: false },
     )
 }

--- a/cli/src/progress.rs
+++ b/cli/src/progress.rs
@@ -107,14 +107,22 @@ where
         let progress_fn = progress_fn;
         let statistics = Arc::clone(&statistics);
         let sleep_duration = Duration::from_millis(100);
+        let mut current_max = max_progress_value;
 
         while report_progress.load(Ordering::SeqCst) {
             thread::sleep(sleep_duration);
             let (progress_value, message) = progress_fn(&statistics);
             progress_bar.set_position(progress_value);
             progress_bar.set_prefix(message);
-            match max_progress_value {
-                Some(value) => progress_bar.set_message(format!("{progress_value} / {value}")),
+            match current_max {
+                Some(value) => {
+                    let display_total = progress_value.max(value);
+                    if display_total > value {
+                        progress_bar.set_length(display_total);
+                        current_max = Some(display_total);
+                    }
+                    progress_bar.set_message(format!("{progress_value} / {display_total}"));
+                }
                 None => progress_bar.set_message(format!("{progress_value}")),
             };
         }


### PR DESCRIPTION
## Summary
- The IXP progress bar averaged three independent counters (`num_comments`, `num_docs_downloaded`, `num_docs_written`) and divided by three, then compared the result to an approximate up-front comment count. In practice this displayed e.g. `974 / 857` near the end of a download.
- IXP bar now treats each comment as three units of work (fetch, doc-download, doc-write): `total = total_comments * 3`, position = sum of the three counters.
- `progress.rs` now grows the bar's length when the live position overtakes the initial total, so `current / total` never inverts even if the up-front estimate is wrong. This also benefits the CM bar.

## Test plan
- [x] `cargo fmt --check -p reinfer-cli`
- [x] `cargo clippy -p reinfer-cli -- -D warnings`
- [x] `cargo test -p reinfer-cli --bin re` (25/25 pass)
- [x] Manual: run `re package download` against an IXP project where the dataset statistics under-count comments; confirm the bar reaches but does not exceed 100%
- [x] Manual: run `re package download` against a CM project; confirm the bar still behaves sensibly

## Notes
The IXP bar still over- or under-shoots when comments have ≠1 attachment (we don't know attachment count up front), but the new overflow handler in `progress.rs` absorbs that — the bar grows instead of inverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)