### PR TITLE
feat(cli, api): filter `get emails` by mailbox name and timerange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Allow `re get emails` to filter by `--mailbox`, `--from-timestamp`, and `--to-timestamp`
+
 # v0.39.1
 - Support `gpt_5_1_2025_11_13`, `gpt_5_4_2026_03_05`, `gemini_2_5_pro`, and `gemini_3_1_pro_preview` model versions
 - Fix downloaded packages placing extension-less documents at the package root instead of in the `documents/` folder

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -125,8 +125,8 @@ pub use crate::{
             ModelVersion, Name as DatasetName, NewDataset, UpdateDataset,
         },
         email::{
-            Continuation as EmailContinuation, EmailsIterPage, Id as EmailId, Mailbox, MimeContent,
-            NewEmail,
+            Continuation as EmailContinuation, EmailsIterPage, EmailsQueryPage, Id as EmailId,
+            Mailbox, MimeContent, NewEmail,
         },
         entity_def::{EntityDef, Id as EntityDefId, Name as EntityName, NewEntityDef},
         integration::FullName as IntegrationFullName,
@@ -248,6 +248,19 @@ pub struct GetEmailsIterPageQuery<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub continuation: Option<&'a EmailContinuation>,
     pub limit: usize,
+}
+
+#[derive(Serialize)]
+pub struct QueryEmailsPageRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<&'a EmailContinuation>,
+    pub limit: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_timestamp: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_timestamp: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mailbox_name: Option<&'a str>,
 }
 
 #[derive(Serialize)]
@@ -519,6 +532,38 @@ impl Client {
         page_size: Option<usize>,
     ) -> EmailsIter<'a> {
         EmailsIter::new(self, bucket_name, page_size)
+    }
+
+    /// Get a page of emails from a bucket filtered by mailbox name and/or timerange.
+    pub fn query_emails_iter_page(
+        &self,
+        bucket_name: &BucketFullName,
+        filter: &EmailsQueryFilter,
+        continuation: Option<&EmailContinuation>,
+        limit: usize,
+    ) -> Result<EmailsQueryPage> {
+        let request = QueryEmailsPageRequest {
+            continuation,
+            limit,
+            from_timestamp: filter.from_timestamp,
+            to_timestamp: filter.to_timestamp,
+            mailbox_name: filter.mailbox_name.as_deref(),
+        };
+        self.post(
+            self.endpoints.query_emails(bucket_name)?,
+            Some(&request),
+            Retry::Yes,
+        )
+    }
+
+    /// Iterate through emails in a bucket filtered by mailbox name and/or timerange.
+    pub fn query_emails_iter<'a>(
+        &'a self,
+        bucket_name: &'a BucketFullName,
+        filter: EmailsQueryFilter,
+        page_size: Option<usize>,
+    ) -> EmailsQueryIter<'a> {
+        EmailsQueryIter::new(self, bucket_name, filter, page_size)
     }
 
     /// Get a single comment by id.
@@ -1743,6 +1788,73 @@ impl Iterator for EmailsIter<'_> {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct EmailsQueryFilter {
+    pub from_timestamp: Option<DateTime<Utc>>,
+    pub to_timestamp: Option<DateTime<Utc>>,
+    pub mailbox_name: Option<String>,
+}
+
+impl EmailsQueryFilter {
+    pub fn is_empty(&self) -> bool {
+        self.from_timestamp.is_none() && self.to_timestamp.is_none() && self.mailbox_name.is_none()
+    }
+}
+
+pub struct EmailsQueryIter<'a> {
+    client: &'a Client,
+    bucket_name: &'a BucketFullName,
+    filter: EmailsQueryFilter,
+    continuation: Option<EmailContinuation>,
+    done: bool,
+    page_size: usize,
+}
+
+impl<'a> EmailsQueryIter<'a> {
+    // Default number of emails per page to request from API.
+    pub const DEFAULT_PAGE_SIZE: usize = 64;
+
+    fn new(
+        client: &'a Client,
+        bucket_name: &'a BucketFullName,
+        filter: EmailsQueryFilter,
+        page_size: Option<usize>,
+    ) -> Self {
+        Self {
+            client,
+            bucket_name,
+            filter,
+            continuation: None,
+            done: false,
+            page_size: page_size.unwrap_or(Self::DEFAULT_PAGE_SIZE),
+        }
+    }
+}
+
+impl Iterator for EmailsQueryIter<'_> {
+    type Item = Result<Vec<Email>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        let response = self.client.query_emails_iter_page(
+            self.bucket_name,
+            &self.filter,
+            self.continuation.as_ref(),
+            self.page_size,
+        );
+        Some(response.map(|page| {
+            self.continuation = page.continuation;
+            // Terminate on `more_results`, not page size: under outline-mode
+            // mailbox filtering a page can be shorter than `limit` while more
+            // matches remain further in the bucket.
+            self.done = !page.more_results;
+            page.emails
+        }))
+    }
+}
+
 pub struct CommentsIter<'a> {
     client: &'a Client,
     source_name: &'a SourceFullName,
@@ -2323,6 +2435,20 @@ impl Endpoints {
         construct_endpoint(
             &self.base,
             &["api", "_private", "buckets", &bucket_name.0, "emails"],
+        )
+    }
+
+    fn query_emails(&self, bucket_name: &BucketFullName) -> Result<Url> {
+        construct_endpoint(
+            &self.base,
+            &[
+                "api",
+                "_private",
+                "buckets",
+                &bucket_name.0,
+                "emails",
+                "query",
+            ],
         )
     }
 

--- a/api/src/resources/email.rs
+++ b/api/src/resources/email.rs
@@ -109,6 +109,14 @@ pub struct EmailsIterPage {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct EmailsQueryPage {
+    pub emails: Vec<Email>,
+    #[serde(default)]
+    pub more_results: bool,
+    pub continuation: Option<Continuation>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct GetEmailResponse {
     pub emails: Vec<Email>,
 }

--- a/cli/src/commands/get/emails.rs
+++ b/cli/src/commands/get/emails.rs
@@ -1,7 +1,11 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 
+use chrono::{DateTime, Utc};
 use colored::Colorize;
-use reinfer_client::{resources::bucket_statistics::Count, BucketIdentifier, Client, EmailId};
+use reinfer_client::{
+    resources::{bucket_statistics::Count, email::Email},
+    BucketIdentifier, Client, EmailId, EmailsQueryFilter,
+};
 use std::{
     fs::File,
     io::{self, BufWriter, Write},
@@ -31,10 +35,31 @@ pub struct GetManyEmailsArgs {
     #[structopt(name = "id")]
     /// Id of specific email to return
     id: Option<EmailId>,
+
+    #[structopt(long = "mailbox")]
+    /// Filter to emails belonging to this exact mailbox name.
+    mailbox: Option<String>,
+
+    #[structopt(long = "from-timestamp")]
+    /// Include only emails with a timestamp greater than or equal to this
+    /// (inclusive). RFC3339, e.g. 2024-01-01T00:00:00Z.
+    from_timestamp: Option<DateTime<Utc>>,
+
+    #[structopt(long = "to-timestamp")]
+    /// Include only emails with a timestamp strictly less than this
+    /// (exclusive). RFC3339, e.g. 2024-02-01T00:00:00Z.
+    to_timestamp: Option<DateTime<Utc>>,
 }
 
 pub fn get_many(client: &Client, args: &GetManyEmailsArgs) -> Result<()> {
-    let GetManyEmailsArgs { bucket, path, id } = args;
+    let GetManyEmailsArgs {
+        bucket,
+        path,
+        id,
+        mailbox,
+        from_timestamp,
+        to_timestamp,
+    } = args;
 
     let file = match path {
         Some(path) => Some(
@@ -46,6 +71,9 @@ pub fn get_many(client: &Client, args: &GetManyEmailsArgs) -> Result<()> {
     };
 
     if let Some(id) = id {
+        if mailbox.is_some() || from_timestamp.is_some() || to_timestamp.is_some() {
+            bail!("`--mailbox`, `--from-timestamp` and `--to-timestamp` cannot be combined with a specific email id.");
+        }
         if let Some(file) = file {
             return download_email(client, bucket.clone(), id.clone(), file);
         } else {
@@ -53,10 +81,24 @@ pub fn get_many(client: &Client, args: &GetManyEmailsArgs) -> Result<()> {
         }
     }
 
+    if let (Some(from), Some(to)) = (from_timestamp, to_timestamp) {
+        if from > to {
+            bail!("`--from-timestamp` must be less than or equal to `--to-timestamp`.");
+        }
+    }
+
+    let filter = EmailsQueryFilter {
+        from_timestamp: *from_timestamp,
+        to_timestamp: *to_timestamp,
+        mailbox_name: mailbox.clone(),
+    };
+    // `None` keeps the existing listing endpoint; any filter uses the query endpoint.
+    let filter = (!filter.is_empty()).then_some(filter);
+
     if let Some(file) = file {
-        download_emails(client, bucket.clone(), file)
+        download_emails(client, bucket.clone(), filter, file)
     } else {
-        download_emails(client, bucket.clone(), io::stdout().lock())
+        download_emails(client, bucket.clone(), filter, io::stdout().lock())
     }
 }
 
@@ -78,37 +120,64 @@ fn download_email(
 fn download_emails(
     client: &Client,
     bucket_identifier: BucketIdentifier,
+    filter: Option<EmailsQueryFilter>,
     mut writer: impl Write,
 ) -> Result<()> {
     let bucket = client
         .get_bucket(bucket_identifier)
         .context("Operation to get bucket has failed.")?;
 
-    let bucket_statistics = client
-        .get_bucket_statistics(&bucket.full_name())
-        .context("Could not get bucket statistics")?;
-
     let statistics = Arc::new(Statistics::new());
 
-    let progress_bytes = match bucket_statistics.count {
-        Count::LowerBoundBucketCount { value } => value,
-        Count::ExactBucketCount { value } => value,
-    } as u64;
+    // An unfiltered listing knows the bucket's total up front and shows a
+    // completion bar. A filtered query has no reliable total (under outline-mode
+    // mailbox filtering a page can be short while more matches remain), so it
+    // shows a count-only indicator.
+    let total = match &filter {
+        None => {
+            let bucket_statistics = client
+                .get_bucket_statistics(&bucket.full_name())
+                .context("Could not get bucket statistics")?;
+            Some(match bucket_statistics.count {
+                Count::LowerBoundBucketCount { value } => value,
+                Count::ExactBucketCount { value } => value,
+            } as u64)
+        }
+        Some(_) => None,
+    };
 
-    let _progress = get_emails_progress_bar(progress_bytes, &statistics);
+    let _progress = get_emails_progress_bar(total, &statistics);
 
-    client
-        .get_emails_iter(&bucket.full_name(), None)
-        .try_for_each(|page| {
-            let page = page.context("Operation to get emails has failed.")?;
-            statistics.add_emails(page.len());
-            print_resources_as_json(page, &mut writer)
-        })?;
+    match filter {
+        Some(filter) => drain_email_pages(
+            client.query_emails_iter(&bucket.full_name(), filter, None),
+            &statistics,
+            &mut writer,
+        )?,
+        None => drain_email_pages(
+            client.get_emails_iter(&bucket.full_name(), None),
+            &statistics,
+            &mut writer,
+        )?,
+    }
+
     log::info!(
         "Successfully downloaded {} emails.",
         statistics.num_downloaded(),
     );
     Ok(())
+}
+
+fn drain_email_pages(
+    mut pages: impl Iterator<Item = reinfer_client::Result<Vec<Email>>>,
+    statistics: &Statistics,
+    mut writer: impl Write,
+) -> Result<()> {
+    pages.try_for_each(|page| {
+        let page = page.context("Operation to get emails has failed.")?;
+        statistics.add_emails(page.len());
+        print_resources_as_json(page, &mut writer)
+    })
 }
 
 #[derive(Debug)]
@@ -134,7 +203,7 @@ impl Statistics {
     }
 }
 
-fn get_emails_progress_bar(total_bytes: u64, statistics: &Arc<Statistics>) -> Progress {
+fn get_emails_progress_bar(total_bytes: Option<u64>, statistics: &Arc<Statistics>) -> Progress {
     Progress::new(
         move |statistics| {
             let num_downloaded = statistics.num_downloaded();
@@ -148,7 +217,7 @@ fn get_emails_progress_bar(total_bytes: u64, statistics: &Arc<Statistics>) -> Pr
             )
         },
         statistics,
-        Some(total_bytes),
+        total_bytes,
         ProgressOptions { bytes_units: false },
     )
 }

--- a/cli/tests/test_buckets.rs
+++ b/cli/tests/test_buckets.rs
@@ -24,6 +24,119 @@ fn test_bucket_lifecycle() {
 }
 
 #[test]
+fn test_get_emails_filter_by_mailbox_and_timerange() {
+    let cli = TestCli::get();
+    let owner = TestCli::project();
+
+    let bucket = format!("{}/test-emails-{}", owner, Uuid::new_v4());
+    cli.run(["create", "bucket", &bucket]);
+
+    // Four emails across two mailboxes and a spread of timestamps.
+    let emails = [
+        ("alice-1", "alice@reinfer.io", "2020-01-01T00:00:00Z"),
+        ("alice-2", "alice@reinfer.io", "2020-02-01T00:00:00Z"),
+        ("bob-1", "bob@reinfer.io", "2020-01-15T00:00:00Z"),
+        ("bob-2", "bob@reinfer.io", "2020-03-01T00:00:00Z"),
+    ];
+    let jsonl = emails
+        .iter()
+        .map(|(id, mailbox, timestamp)| {
+            serde_json::json!({
+                "id": id,
+                "mailbox": mailbox,
+                "timestamp": timestamp,
+                "mime_content": format!(
+                    "Date: {timestamp}\r\nFrom: {mailbox}\r\nTo: support@reinfer.io\r\n\
+                     Subject: {id}\r\nContent-Type: text/plain\r\n\r\nHello from {id}\r\n"
+                ),
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    cli.run_with_stdin(["create", "emails", "-y", "-b", &bucket], jsonl.as_bytes());
+
+    // Extract a sorted list of the given field across the returned JSONL.
+    let field = |output: &str, key: &str| -> Vec<String> {
+        let mut values: Vec<String> = output
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line).unwrap()[key]
+                    .as_str()
+                    .unwrap()
+                    .to_owned()
+            })
+            .collect();
+        values.sort();
+        values
+    };
+
+    // No filter returns every email via the listing endpoint (the `None`
+    // branch of `download_emails`).
+    let all = field(&cli.run(["get", "emails", &bucket]), "id");
+    assert_eq!(
+        all,
+        vec!["alice-1", "alice-2", "bob-1", "bob-2"],
+        "unfiltered get should return all emails"
+    );
+
+    // Filter by mailbox name (exact match).
+    let alice = field(
+        &cli.run(["get", "emails", &bucket, "--mailbox", "alice@reinfer.io"]),
+        "id",
+    );
+    assert_eq!(alice, vec!["alice-1", "alice-2"], "alice mailbox filter");
+
+    // Filter by timerange [from inclusive, to exclusive): catches alice-2 and bob-1.
+    let in_range = field(
+        &cli.run([
+            "get",
+            "emails",
+            &bucket,
+            "--from-timestamp",
+            "2020-01-10T00:00:00Z",
+            "--to-timestamp",
+            "2020-02-15T00:00:00Z",
+        ]),
+        "id",
+    );
+    assert_eq!(in_range, vec!["alice-2", "bob-1"], "timerange filter");
+
+    // Combined mailbox + timerange narrows to only alice-2.
+    let combined = field(
+        &cli.run([
+            "get",
+            "emails",
+            &bucket,
+            "--mailbox",
+            "alice@reinfer.io",
+            "--from-timestamp",
+            "2020-01-10T00:00:00Z",
+            "--to-timestamp",
+            "2020-02-15T00:00:00Z",
+        ]),
+        "id",
+    );
+    assert_eq!(combined, vec!["alice-2"], "mailbox + timerange filter");
+
+    // `from` after `to` is rejected client-side before hitting the API.
+    let error = cli.run_and_error([
+        "get",
+        "emails",
+        &bucket,
+        "--from-timestamp",
+        "2020-02-01T00:00:00Z",
+        "--to-timestamp",
+        "2020-01-01T00:00:00Z",
+    ]);
+    assert!(error.contains("must be less than or equal to"), "{}", error);
+
+    cli.run(["delete", "bucket", &bucket]);
+}
+
+#[test]
 fn test_create_without_org_fails() {
     let cli = TestCli::get();
 


### PR DESCRIPTION
## What
Adds `--mailbox`, `--from-timestamp`, and `--to-timestamp` flags to `re get emails`, so users can query a bucket's raw emails by mailbox and/or time range instead of downloading the whole bucket.

```
re get emails <bucket> --mailbox alice@example.com
re get emails <bucket> --from-timestamp 2024-01-01T00:00:00Z --to-timestamp 2024-02-01T00:00:00Z
re get emails <bucket> --mailbox alice@example.com --from-timestamp 2024-01-01T00:00:00Z --to-timestamp 2024-02-01T00:00:00Z
```