### PR TITLE
feat(cli, api): add `re delete emails` to delete emails by id from a bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Add `re delete emails` to delete emails by id from a bucket
+
 # v0.40.0
 - Allow `re get emails` to filter by `--mailbox`, `--from-timestamp`, and `--to-timestamp`
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -418,6 +418,22 @@ impl Client {
         )
     }
 
+    /// Delete emails by id in a bucket.
+    pub fn delete_emails(
+        &self,
+        bucket: impl Into<BucketIdentifier>,
+        emails: &[EmailId],
+    ) -> Result<()> {
+        let bucket_full_name = match bucket.into() {
+            bucket @ BucketIdentifier::Id(_) => self.get_bucket(bucket)?.full_name(),
+            BucketIdentifier::FullName(bucket_full_name) => bucket_full_name,
+        };
+        self.delete_query(
+            self.endpoints.delete_emails(&bucket_full_name)?,
+            Some(&id_list_query(emails.iter().map(|id| &id.0))),
+        )
+    }
+
     /// Get a page of comments from a source.
     pub fn get_comments_iter_page(
         &self,
@@ -2453,6 +2469,13 @@ impl Endpoints {
     }
 
     fn put_emails(&self, bucket_name: &BucketFullName) -> Result<Url> {
+        construct_endpoint(
+            &self.base,
+            &["api", "_private", "buckets", &bucket_name.0, "emails"],
+        )
+    }
+
+    fn delete_emails(&self, bucket_name: &BucketFullName) -> Result<Url> {
         construct_endpoint(
             &self.base,
             &["api", "_private", "buckets", &bucket_name.0, "emails"],

--- a/cli/src/commands/delete.rs
+++ b/cli/src/commands/delete.rs
@@ -11,7 +11,7 @@ use structopt::StructOpt;
 use reinfer_client::{
     resources::{bucket::GetKeyedSyncStateIdsRequest, project::ForceDeleteProject},
     BucketIdentifier, Client, CommentId, CommentsIter, CommentsIterTimerange, DatasetIdentifier,
-    ProjectName, Source, SourceIdentifier, UserIdentifier,
+    EmailId, ProjectName, Source, SourceIdentifier, UserIdentifier,
 };
 
 use crate::progress::{Options as ProgressOptions, Progress};
@@ -36,6 +36,18 @@ pub enum DeleteArgs {
         #[structopt(name = "comment id")]
         /// Ids of the comments to delete
         comments: Vec<CommentId>,
+    },
+
+    #[structopt(name = "emails")]
+    /// Delete emails by id in a bucket.
+    Emails {
+        #[structopt(short = "b", long = "bucket")]
+        /// Name or id of the bucket to delete emails from
+        bucket: BucketIdentifier,
+
+        #[structopt(name = "email id")]
+        /// Ids of the emails to delete
+        emails: Vec<EmailId>,
     },
 
     #[structopt(name = "bulk")]
@@ -133,6 +145,12 @@ pub fn run(delete_args: &DeleteArgs, client: Client) -> Result<()> {
                 .delete_comments(source.clone(), comments)
                 .context("Operation to delete comments has failed.")?;
             log::info!("Deleted comments.");
+        }
+        DeleteArgs::Emails { bucket, emails } => {
+            client
+                .delete_emails(bucket.clone(), emails)
+                .context("Operation to delete emails has failed.")?;
+            log::info!("Deleted emails.");
         }
         DeleteArgs::BulkComments {
             source: source_identifier,

--- a/cli/tests/test_buckets.rs
+++ b/cli/tests/test_buckets.rs
@@ -137,6 +137,82 @@ fn test_get_emails_filter_by_mailbox_and_timerange() {
 }
 
 #[test]
+fn test_delete_emails() {
+    let cli = TestCli::get();
+    let owner = TestCli::project();
+
+    let bucket = format!("{}/test-delete-emails-{}", owner, Uuid::new_v4());
+    cli.run(["create", "bucket", &bucket]);
+
+    // Three emails in the bucket.
+    let emails = [
+        ("keep", "alice@reinfer.io", "2020-01-01T00:00:00Z"),
+        ("delete-1", "bob@reinfer.io", "2020-02-01T00:00:00Z"),
+        ("delete-2", "carol@reinfer.io", "2020-03-01T00:00:00Z"),
+    ];
+    let jsonl = emails
+        .iter()
+        .map(|(id, mailbox, timestamp)| {
+            serde_json::json!({
+                "id": id,
+                "mailbox": mailbox,
+                "timestamp": timestamp,
+                "mime_content": format!(
+                    "Date: {timestamp}\r\nFrom: {mailbox}\r\nTo: support@reinfer.io\r\n\
+                     Subject: {id}\r\nContent-Type: text/plain\r\n\r\nHello from {id}\r\n"
+                ),
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    cli.run_with_stdin(["create", "emails", "-y", "-b", &bucket], jsonl.as_bytes());
+
+    // Sorted list of email ids currently in the bucket.
+    let ids = |output: &str| -> Vec<String> {
+        let mut values: Vec<String> = output
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| {
+                serde_json::from_str::<serde_json::Value>(line).unwrap()["id"]
+                    .as_str()
+                    .unwrap()
+                    .to_owned()
+            })
+            .collect();
+        values.sort();
+        values
+    };
+
+    assert_eq!(
+        ids(&cli.run(["get", "emails", &bucket])),
+        vec!["delete-1", "delete-2", "keep"],
+        "all three emails should be present before deletion"
+    );
+
+    // Delete two of the three by id.
+    let output = cli.run(["delete", "emails", "-b", &bucket, "delete-1", "delete-2"]);
+    assert!(output.is_empty(), "{}", output);
+
+    assert_eq!(
+        ids(&cli.run(["get", "emails", &bucket])),
+        vec!["keep"],
+        "only the un-deleted email should remain"
+    );
+
+    // Deletion is idempotent: deleting an already-deleted / missing id succeeds.
+    let output = cli.run(["delete", "emails", "-b", &bucket, "delete-1", "does-not-exist"]);
+    assert!(output.is_empty(), "{}", output);
+    assert_eq!(
+        ids(&cli.run(["get", "emails", &bucket])),
+        vec!["keep"],
+        "idempotent delete of missing ids should not affect remaining emails"
+    );
+
+    cli.run(["delete", "bucket", &bucket]);
+}
+
+#[test]
 fn test_create_without_org_fails() {
     let cli = TestCli::get();
 

--- a/cli/tests/test_buckets.rs
+++ b/cli/tests/test_buckets.rs
@@ -201,7 +201,14 @@ fn test_delete_emails() {
     );
 
     // Deletion is idempotent: deleting an already-deleted / missing id succeeds.
-    let output = cli.run(["delete", "emails", "-b", &bucket, "delete-1", "does-not-exist"]);
+    let output = cli.run([
+        "delete",
+        "emails",
+        "-b",
+        &bucket,
+        "delete-1",
+        "does-not-exist",
+    ]);
     assert!(output.is_empty(), "{}", output);
     assert_eq!(
         ids(&cli.run(["get", "emails", &bucket])),


### PR DESCRIPTION
## What
Adds a `re delete emails` command (and the underlying `Client::delete_emails` API method) to delete emails from a bucket by id:

```
re delete emails --bucket <bucket> <email-id>...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)