### PR TITLE
fix(cli): make TestDataset teardown best-effort to fix flaky copy-annotations test

### DIFF
--- a/cli/tests/test_datasets.rs
+++ b/cli/tests/test_datasets.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use backoff::{retry, ExponentialBackoff};
 use pretty_assertions::assert_eq;
 use reinfer_client::{
@@ -87,7 +89,25 @@ impl Drop for TestDataset {
                 .map_err(backoff::Error::transient)
         };
 
-        retry(ExponentialBackoff::default(), delete_dataset_command).unwrap();
+        // Best-effort cleanup: deleting the dataset can fail transiently (e.g. a dataset
+        // that is the source of an in-progress `--copy-annotations-from` is locked
+        // server-side and returns 403 until the copy finishes). We retry briefly, but if it
+        // still fails we orphan the dataset rather than panic — a failed teardown must not
+        // fail the test, and panicking in `drop` risks aborting the whole test process.
+        //
+        // The retry window is deliberately short: a copy can hold the lock for well over
+        // the default 15-minute window, and we orphan in that case anyway, so a long retry
+        // would just make the drop (and the whole test suite) hang for no benefit.
+        let backoff = ExponentialBackoff {
+            max_elapsed_time: Some(Duration::from_secs(60)),
+            ..Default::default()
+        };
+        if let Err(err) = retry(backoff, delete_dataset_command) {
+            eprintln!(
+                "warning: failed to delete test dataset `{}`, orphaning it: {err}",
+                self.identifier()
+            );
+        }
     }
 }
 


### PR DESCRIPTION
`test_create_dataset_copy_annotations` intermittently failed CI. The test kicks off an async `--copy-annotations-from`, which locks the source dataset server-side; the RAII `TestDataset::drop` then `.unwrap()`ed a failed delete and panicked — failing the test (and risking aborting the process) over a teardown issue.

Teardown is now best-effort: retry the delete briefly (60s), then log a warning and orphan the dataset instead of panicking. The retry window is deliberately short — the copy can hold the lock for well over the previous 15-minute default, and we orphan in that case regardless, so a long retry only made the drop hang.

Verified against the test backend: the test now passes (the previously-panicking 403 becomes a warning) and drops from ~875s to ~68s — that one test had been dominating the whole suite's runtime.

RE-12798
