### PR TITLE
fix(cli): drop autotools build dependency now that libpff builds from a release tarball

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,25 +22,12 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Setup mac dependencies 
-        if: matrix.os == 'macos-15'
-        run: |
-          # Create directory for Macport installs
-          sudo mkdir -p /opt/local
-          
-          # Conigure permissions on that directory
-          sudo chmod -R 777 /opt/local
-         
-          # Add the path to GITHUB_PATH
-          echo "/opt/local/bin:/opt/local/sbin" >> "$GITHUB_PATH"
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-            cli/libpff-20231205
-            /opt/local
           key: ${{ runner.os }}-build-${{ hashFiles('**/Cargo.lock', 'scripts/build-install') }}
 
       - name: Install build deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,11 +22,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-            cli/libpff-20231205
           key: ${{ runner.os }}-build-${{ hashFiles('**/Cargo.lock', 'scripts/build-install') }}
 
       - name: Install build dependencies
-        run: sudo apt install git autoconf automake autopoint libtool pkg-config
+        run: sudo apt install pkg-config
       # Needs to be separate job because clippy currently (incorrectly) shares cache with cargo
       # (See https://github.com/rust-lang/rust-clippy/issues/4612)
 
@@ -41,25 +40,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup mac dependencies 
-        if: matrix.os == 'macos-15'
-        run: |
-          # Create directory for Macport installs
-          sudo mkdir -p /opt/local
-          
-          # Conigure permissions on that directory
-          sudo chmod -R 777 /opt/local
-         
-          # Add the path to GITHUB_PATH
-          echo "/opt/local/bin:/opt/local/sbin" >> "$GITHUB_PATH"
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-            cli/libpff-20231205
-            /opt/local
           key: ${{ runner.os }}-build-${{ hashFiles('**/Cargo.lock', 'scripts/build-install') }}
 
       - name: Install build deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+- Drop the autotools build dependency: libpff now builds from a release tarball that ships a
+  pre-generated `configure`, so `autoconf`/`automake`/`libtool` (and the macOS MacPorts bootstrap)
+  are no longer required to build from source
+
 # v0.41.0
 - Add `re prune` to delete comments and emails older than a cutoff, backing them up to disk first
   (optionally scoped to a single mailbox via `--mailbox`)

--- a/README.md
+++ b/README.md
@@ -120,13 +120,15 @@ Make sure you have the following build dependencies installed:
 ##### Debian/Ubuntu
 
 ```
-sudo apt install autoconf automake autopoint libtool pkg-config
+sudo apt install build-essential pkg-config curl zlib1g-dev
 ```
 
 ##### macOS
 
+Install the Xcode Command Line Tools, which provide the C compiler and `make`:
+
 ```
-sudo port install autoconf automake gettext libtool pkgconfig
+xcode-select --install
 ```
 
 Build it the usual way using cargo

--- a/scripts/build-install
+++ b/scripts/build-install
@@ -5,23 +5,15 @@ set -ex
 case $BUILD_PLATFORM in
   "ubuntu-24.04")
     sudo apt-get install          \
-      autoconf                    \
-      automake                    \
-      autopoint                   \
-      libtool                     \
       pkg-config                  \
       musl-tools
     ;;
   "macos-15")
-    wget https://github.com/macports/macports-base/releases/download/v2.10.5/MacPorts-2.10.5-15-Sequoia.pkg
-    sudo installer -pkg MacPorts-2.10.5-15-Sequoia.pkg -target /
-    export PATH=/opt/local/bin:/opt/local/sbin:$PATH
-    sudo port install             \
-      autoconf                    \
-      automake                    \
-      gettext                     \
-      libtool                     \
-      pkgconfig
+    # libpff now builds from a release tarball that ships a pre-generated
+    # `configure`, so autotools are no longer required. The remaining build
+    # dependencies (C compiler, make) come from the Xcode Command Line Tools,
+    # which are preinstalled on the macOS runner -- nothing to install here.
+    :
     ;;
   *)
     >&2 echo "fatal: unknown BUILD_PLATFORM '$BUILD_PLATFORM'"


### PR DESCRIPTION
## Summary

PR #443 switched the libpff build (PST parsing) from cloning libyal via
`synclibs.sh`/`autogen.sh` to libyal's release tarball, which ships a
pre-generated `configure` — removing the autoconf/automake (autotools) build
requirement. That shipped in v0.40.0 (crates.io now at 0.41.x). This PR is the
follow-up cleanup that removes the now-dead autotools scaffolding.

Verified locally on macOS with autoconf/automake **absent** and no MacPorts: a
clean from-scratch libpff build (download tarball → vendored `./configure` →
`make`) succeeds, so the dropped tooling is genuinely unused.

## Changes

- **`scripts/build-install`** — Ubuntu path drops `autoconf`/`automake`/`autopoint`/`libtool`
  (keeps `pkg-config` + `musl-tools`); macOS path drops the MacPorts bootstrap
  entirely (C compiler + `make` come from the preinstalled Xcode CLT).
- **`.github/workflows/rust.yml`** — remove autotools (and the now-dead `git`,
  previously needed by `synclibs.sh`) from the clippy `apt install`; drop the
  macOS MacPorts setup step and the stale `cli/libpff-20231205` / `/opt/local`
  cache paths.
- **`.github/workflows/publish.yml`** — drop the same macOS setup step and stale
  cache paths.
- **`README.md`** — replace the autotools/MacPorts install instructions with the
  deps actually required to build from source (`build-essential pkg-config curl
  zlib1g-dev` on Debian/Ubuntu; Xcode CLT on macOS).
- **`CHANGELOG.md`** — add an `# Unreleased` entry.

Closes RE-12487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)