### PR TITLE
fix(cli, api): replace stale Re:infer branding with UiPath IXP in user-facing strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- Update `--help` text, the READMEs and the crate descriptions to refer to UiPath IXP rather than
+  Re:infer, and print `re` rather than `reinfer-cli` in `re --help` and `re --version`. The config
+  file location (`~/.config/reinfer`), the `REINFER_CLI_NUM_THREADS` environment variable, the
+  `--reinfer-tenant-id` flag and the `reinfer-cli`/`reinfer-client` crate names are unchanged
+
 # v0.42.0
 - Fix `re get datasets`, `re prune`, `re get custom-label-trend-report` and `re package upload`
   failing for a whole tenant when any one of its datasets used an attribution method, model version,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://docs.uipath.com/communications-mining/automation-cloud/latest/developer-guide/overview-cli">
-    <img alt="reinfer-cli" src="https://avatars.githubusercontent.com/u/375663?s=200&v=4" width="128">
+    <img alt="UiPath IXP CLI" src="https://avatars.githubusercontent.com/u/375663?s=200&v=4" width="128">
   </a>
 </p>
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reinfer-client"
 version = "0.42.0"
-description = "API client for Re:infer, the conversational data intelligence platform"
+description = "API client for UiPath IXP"
 homepage = "https://github.com/reinfer/cli"
 readme = "README.md"
 authors = ["reinfer Ltd. <eng@reinfer.io>"]

--- a/api/README.md
+++ b/api/README.md
@@ -1,3 +1,3 @@
-# API Library for reinfer
+# API Library for UiPath IXP
 
-A Rust library for the reinfer API.
+A Rust library for the UiPath IXP API.

--- a/api/src/retry.rs
+++ b/api/src/retry.rs
@@ -15,7 +15,7 @@ pub enum RetryStrategy {
     Always,
 }
 
-/// Configuration for the Reinfer client if retrying timeouts.
+/// Configuration for the IXP client if retrying timeouts.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RetryConfig {
     /// Strategy for when to retry after a timeout

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reinfer-cli"
 version = "0.42.0"
-description = "Command line interface for Re:infer, the conversational data intelligence platform"
+description = "Command line interface for UiPath IXP"
 homepage = "https://github.com/reinfer/cli"
 readme = "README.md"
 authors = ["reinfer Ltd. <eng@reinfer.io>"]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -10,9 +10,10 @@ use reqwest::Url;
 use std::{path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 
-/// re is the command line interface to reinfer clusters.
+/// re is the command line interface for UiPath IXP.
 #[derive(Debug, StructOpt)]
 #[structopt(
+    name = "re",
     global_settings = &[
         structopt::clap::AppSettings::ColoredHelp,
         structopt::clap::AppSettings::InferSubcommands,
@@ -71,7 +72,7 @@ pub enum Command {
     Completion { shell: Shell },
 
     #[structopt(name = "config")]
-    /// Manage reinfer authentication and endpoint contexts
+    /// Manage IXP authentication and endpoint contexts
     Config {
         #[structopt(subcommand)]
         config_args: ConfigArgs,

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -16,18 +16,18 @@ use anyhow::{anyhow, Result};
 #[derive(Debug, StructOpt)]
 pub enum ConfigArgs {
     #[structopt(name = "add")]
-    /// Add a new context to the reinfer config file
+    /// Add a new context to the config file
     AddContext {
         #[structopt(long = "name", short = "n")]
         /// The name of the context that will be created or updated
         name: Option<String>,
 
         #[structopt(long = "endpoint", short = "e")]
-        /// The reinfer cluster endpoint that will be used for this context
+        /// The IXP cluster endpoint that will be used for this context
         endpoint: Option<Url>,
 
         #[structopt(long = "token", short = "t")]
-        /// The reinfer API token that will be used for this context
+        /// The IXP API token that will be used for this context
         token: Option<String>,
 
         #[structopt(long = "accept-invalid-certificates", short = "k")]
@@ -48,14 +48,14 @@ pub enum ConfigArgs {
     CurrentContext,
 
     #[structopt(name = "delete")]
-    /// Delete the specified context from the reinfer config file
+    /// Delete the specified context from the config file
     DeleteContext {
         /// The name(s) of the context(s) which will be deleted
         names: Vec<String>,
     },
 
     #[structopt(name = "ls")]
-    /// List available contexts in a reinfer config file
+    /// List available contexts in the config file
     ListContexts {
         #[structopt(long = "tokens")]
         /// Show API tokens (by default tokens are hidden).
@@ -63,7 +63,7 @@ pub enum ConfigArgs {
     },
 
     #[structopt(name = "use")]
-    /// Set the current context in the reinfer config file
+    /// Set the current context in the config file
     UseContext {
         /// The name of the context.
         name: String,
@@ -83,7 +83,7 @@ pub enum ConfigArgs {
         /// The URL to be parsed
         #[structopt(long = "url", short = "u")]
         url: Option<Url>,
-        /// The reinfer API token that will be used for this context
+        /// The IXP API token that will be used for this context
         #[structopt(long = "token", short = "t")]
         token: Option<String>,
     },


### PR DESCRIPTION
The `re` CLI still opened with `reinfer-cli 0.42.0` / "re is the command line interface to reinfer clusters", and every `re config` subcommand described "the reinfer config file" — while the README had already moved to UiPath IXP. This sweeps the user-facing strings over.

- `re --help` / `re --version` now print `re 0.42.0` (`name = "re"` on the root `structopt` — the crate is still `reinfer-cli`, and the binary was always `re`)
- Root about, the `config` about, and the seven `re config` help strings
- Both crate `description`s — the crates.io/docs.rs blurbs, and the Debian `Description:` via `cargo deb`
- `api/README.md`, the `RetryConfig` rustdoc, and the README logo's `alt` text

Deliberately unchanged as compatibility surfaces rather than branding: the `reinfer-cli`/`reinfer-client` crate names, `~/.config/reinfer`, `REINFER_CLI_NUM_THREADS`, `reinfer.dev` endpoint handling, the `reinfer_` URL path segment (including the `parse-from-url` error text that quotes it), and the internal `ReinferConfig` symbols. `--reinfer-tenant-id` on `re create quota` keeps its name *and* its help text — it labels an ID namespace (`TenantId::Reinfer` vs `TenantId::UiPath`) and is mutually exclusive with `--uipath-tenant-id`, so rebranding just the help would make the two flags read as the same thing.

Left for a separate call: `authors = ["reinfer Ltd. <eng@reinfer.io>"]` in both manifests (an attribution record, and the `.deb` `Maintainer:`), and the hero image — still the Re:infer GitHub org avatar, only its `alt` text changed here.

Verified by walking all 71 help pages and the generated zsh/bash completions: the only `reinfer` left is the four exclusions above. `scripts/check-versions`, `cargo fmt --check` and `cargo clippy --all-targets -D warnings` pass. No runtime behaviour changes and nothing asserts on help text, so no new tests — `cargo test` needs a live cluster and is left to CI.

RE-12805
